### PR TITLE
Fix for xls 97 2003 on windows set file on readonly to avoid hash change

### DIFF
--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/CompressedFileToArchiveTransferImporter.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/CompressedFileToArchiveTransferImporter.java
@@ -112,6 +112,11 @@ public class CompressedFileToArchiveTransferImporter {
      * The GlobalMetaData file path .
      */
     private Path onDiskGlobalMetadataPath;
+    
+    /**
+     * The is windows.
+     */
+    private boolean isWindows;
 
     /**
      * The start and end instants, for duration computation.
@@ -237,6 +242,16 @@ public class CompressedFileToArchiveTransferImporter {
                         doProgressLog(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS,
                                 "Décompresse le fichier [" + entryName + "]", null);
                         Files.copy(archiveInputStream, target, StandardCopyOption.REPLACE_EXISTING);
+                        // Fix for xls 97 2003 on windows
+                        if (isWindows) {
+                            // Set read-only
+                            try {
+                                Files.setAttribute(target, "dos:readonly", true);
+                            } catch (IOException e) {
+                                doProgressLog(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_WARNINGS,
+                                        "Impossible de passer Le chemin [" + target.toString() + "] en lecture seule", e);
+                            }
+                        }
                         counter++;
                         doProgressLogIfStep(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_GROUP, counter,
                                 Integer.toString(counter) +
@@ -328,6 +343,8 @@ public class CompressedFileToArchiveTransferImporter {
     public void doImport() throws SEDALibException, InterruptedException {
         Path path;
         Iterator<Path> pi;
+        
+        isWindows = System.getProperty("os.name").toLowerCase().contains("win");
 
         Date d = new Date();
         start = Instant.now();

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/DIPToArchiveDeliveryRequestReplyImporter.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/DIPToArchiveDeliveryRequestReplyImporter.java
@@ -84,6 +84,11 @@ public class DIPToArchiveDeliveryRequestReplyImporter {
      * The progress logger.
      */
     private SEDALibProgressLogger sedaLibProgressLogger;
+    
+    /**
+     * The is windows.
+     */
+    private boolean isWindows;
 
     /**
      * Unzip file.
@@ -136,6 +141,16 @@ public class DIPToArchiveDeliveryRequestReplyImporter {
 
                     FileOutputStream fos = new FileOutputStream(newPath.toFile());
                     IOUtils.copy(zais, fos);
+                    // Fix for xls 97 2003 on windows
+                    if (isWindows) {
+                        // Set read-only
+                        try {
+                            Files.setAttribute(newPath, "dos:readonly", true);
+                        } catch (IOException e) {
+                            doProgressLog(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_WARNINGS,
+                                    "Impossible de passer le chemin [" + newPath.toString() + "] en lecture seule", e);
+                        }
+                    }
                     counter++;
                     doProgressLogIfStep(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_GROUP, counter, "sedalib: " + counter + " fichiers " +
                                 "extraits");
@@ -164,6 +179,8 @@ public class DIPToArchiveDeliveryRequestReplyImporter {
     public DIPToArchiveDeliveryRequestReplyImporter(String zipFile, String unCompressDirectory,
                                                     SEDALibProgressLogger sedaLibProgressLogger) throws SEDALibException {
         Path zipFilePath, unCompressDirectoryPath;
+        
+        isWindows = System.getProperty("os.name").toLowerCase().contains("win");
 
         zipFilePath = Paths.get(zipFile);
         if (!Files.isRegularFile(zipFilePath, java.nio.file.LinkOption.NOFOLLOW_LINKS))

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/DiskToDataObjectPackageImporter.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/DiskToDataObjectPackageImporter.java
@@ -784,6 +784,16 @@ public class DiskToDataObjectPackageImporter {
         inCounter++;
         doProgressLogIfStep(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_GROUP, inCounter, "sedalib: " + inCounter +
                     " ArchiveUnits importées");
+        // Fix for xls 97 2003 on windows
+        if (isWindows) {
+            // Set read-only
+            try {
+                Files.setAttribute(path, "dos:readonly", true);
+            } catch (IOException e) {
+                doProgressLog(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_WARNINGS,
+                        "Impossible de passer Le chemin [" + path.toString() + "] en lecture seule", e);
+            }
+        }
 
         dog = new DataObjectGroup(dataObjectPackage, path);
         bdo = new BinaryDataObject(dataObjectPackage, path, null, "BinaryMaster_1");

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/SIPToArchiveTransferImporter.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/importer/SIPToArchiveTransferImporter.java
@@ -83,6 +83,11 @@ public class SIPToArchiveTransferImporter {
      * The progress logger.
      */
     private SEDALibProgressLogger sedaLibProgressLogger;
+    
+    /**
+     * The is windows.
+     */
+    private boolean isWindows;
 
     /**
      * Unzip file.
@@ -135,6 +140,16 @@ public class SIPToArchiveTransferImporter {
 
                     FileOutputStream fos = new FileOutputStream(newPath.toFile());
                     IOUtils.copy(zais, fos);
+                    // Fix for xls 97 2003 on windows
+                    if (isWindows) {
+                        // Set read-only
+                        try {
+                            Files.setAttribute(newPath, "dos:readonly", true);
+                        } catch (IOException e) {
+                            doProgressLog(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_WARNINGS,
+                                    "Impossible de passer le chemin [" + newPath.toString() + "] en lecture seule", e);
+                        }
+                    }
                     counter++;
                     doProgressLogIfStep(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_GROUP, counter, Integer.toString(counter) +
                             " fichiers extraits");
@@ -162,6 +177,8 @@ public class SIPToArchiveTransferImporter {
      */
     public SIPToArchiveTransferImporter(String zipFile, String unCompressDirectory, SEDALibProgressLogger sedaLibProgressLogger) throws SEDALibException {
         Path zipFilePath, unCompressDirectoryPath;
+        
+        isWindows = System.getProperty("os.name").toLowerCase().contains("win");
 
         zipFilePath = Paths.get(zipFile);
         if (!Files.isRegularFile(zipFilePath, java.nio.file.LinkOption.NOFOLLOW_LINKS))

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/BinaryDataObjectTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/BinaryDataObjectTest.java
@@ -7,8 +7,12 @@ import fr.gouv.vitam.tools.sedalib.core.json.DataObjectPackageDeserializer;
 import fr.gouv.vitam.tools.sedalib.core.json.DataObjectPackageSerializer;
 import fr.gouv.vitam.tools.sedalib.inout.importer.SIPToArchiveTransferImporter;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 
 import static fr.gouv.vitam.tools.sedalib.TestUtilities.LineEndNormalize;
@@ -191,5 +195,11 @@ class BinaryDataObjectTest {
         bdoNextOut = LineEndNormalize(bdoNextOut);
         assertThat(bdoNextOut).isEqualTo(testOut);
 
+    }
+    
+    //Cleaning tmp folder
+    @AfterEach
+    public void deleteOutputFile() throws IOException, InterruptedException {
+        FileUtils.deleteQuietly(new File("target/tmpJunit/"));
     }
 }

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackageTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackageTest.java
@@ -16,6 +16,12 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
+
 class DataObjectPackageTest {
 
     @Test
@@ -611,5 +617,11 @@ class DataObjectPackageTest {
         String sau = mapper.writeValueAsString(au);
     //    System.out.println(sau);
         assertEquals(LineEndNormalize(testau), LineEndNormalize(sau));
+    }
+    
+    //Cleaning tmp folder
+    @AfterEach
+    public void deleteOutputFile() throws IOException, InterruptedException {
+        FileUtils.deleteQuietly(new File("target/tmpJunit/"));
     }
 }

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/PhysicalDataObjectTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/PhysicalDataObjectTest.java
@@ -7,8 +7,12 @@ import fr.gouv.vitam.tools.sedalib.core.json.DataObjectPackageDeserializer;
 import fr.gouv.vitam.tools.sedalib.core.json.DataObjectPackageSerializer;
 import fr.gouv.vitam.tools.sedalib.inout.importer.SIPToArchiveTransferImporter;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
+import java.io.File;
 import java.io.IOException;
 
 import static fr.gouv.vitam.tools.sedalib.TestUtilities.LineEndNormalize;
@@ -157,5 +161,11 @@ class PhysicalDataObjectTest {
         pdoNextOut = LineEndNormalize(pdoNextOut);
         assertThat(pdoNextOut).isEqualTo(testOut);
 
+    }
+    
+    //Cleaning tmp folder
+    @AfterEach
+    public void deleteOutputFile() throws IOException, InterruptedException {
+        FileUtils.deleteQuietly(new File("target/tmpJunit/"));
     }
 }

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/ArchiveDeliveryRequestReplyFromXmlTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/ArchiveDeliveryRequestReplyFromXmlTest.java
@@ -15,6 +15,11 @@ import org.junit.jupiter.api.Test;
 import static fr.gouv.vitam.tools.sedalib.TestUtilities.LineEndNormalize;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.AfterEach;
+
 class ArchiveDeliveryRequestReplyFromXmlTest {
 
 	@Test
@@ -106,5 +111,20 @@ class ArchiveDeliveryRequestReplyFromXmlTest {
 		testog = testog.replaceAll("\"onDiskPath\" : .*\"", "");
 		assertEquals(LineEndNormalize(testog),LineEndNormalize(sog));
 	}
+	
+	@AfterEach
+    public void deleteOutputFile() throws IOException, InterruptedException {
+        recursiveDelete(new File("target/tmpJunit/"));
+    }
+    
+    private void recursiveDelete(File inFile) throws IOException, InterruptedException {
+        if (inFile.isDirectory()) {
+            for (File f : inFile.listFiles())
+                recursiveDelete(f);
+            inFile.delete();
+        } else {
+            inFile.delete();
+        }
+    }
 
 }

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/CompressedFileImportTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/CompressedFileImportTest.java
@@ -12,9 +12,11 @@ import fr.gouv.vitam.tools.sedalib.core.json.DataObjectPackageDeserializer;
 import fr.gouv.vitam.tools.sedalib.core.json.DataObjectPackageSerializer;
 import fr.gouv.vitam.tools.sedalib.inout.importer.CompressedFileToArchiveTransferImporter;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.function.Function;
@@ -279,5 +281,20 @@ public class CompressedFileImportTest implements UseTestFiles {
 
         assertThat(saupath).isEqualTo(testaupath);
         assertThat(sau).isEqualTo(testau);
+    }
+    
+    @AfterEach
+    public void deleteOutputFile() throws IOException, InterruptedException {
+        recursiveDelete(new File("target/tmpJunit/"));
+    }
+    
+    private void recursiveDelete(File inFile) throws IOException, InterruptedException {
+        if (inFile.isDirectory()) {
+            for (File f : inFile.listFiles())
+                recursiveDelete(f);
+            inFile.delete();
+        } else {
+            inFile.delete();
+        }
     }
 }

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/SEDAValidationTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/SEDAValidationTest.java
@@ -7,9 +7,14 @@ import fr.gouv.vitam.tools.sedalib.core.GlobalMetadata;
 import fr.gouv.vitam.tools.sedalib.inout.importer.DiskToArchiveTransferImporter;
 import fr.gouv.vitam.tools.sedalib.inout.importer.SIPToArchiveTransferImporter;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+
+import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLStreamException;
+
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -156,4 +161,10 @@ class SEDAValidationTest implements UseTestFiles {
 	}
 
 	// TODO testWithXSD
+	
+	//Cleaning tmp folder
+    @AfterEach
+    public void deleteOutputFile() throws IOException, InterruptedException {
+        FileUtils.deleteQuietly(new File("target/tmpJunit/"));
+    }
 }

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/SIPImportTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/SIPImportTest.java
@@ -16,9 +16,11 @@ import fr.gouv.vitam.tools.sedalib.inout.exporter.ArchiveTransferToSIPExporter;
 import fr.gouv.vitam.tools.sedalib.inout.importer.DiskToArchiveTransferImporter;
 import fr.gouv.vitam.tools.sedalib.inout.importer.SIPToArchiveTransferImporter;
 import org.apache.commons.io.FileUtils;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 import java.io.File;
+import java.io.IOException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -691,5 +693,11 @@ public class SIPImportTest implements UseTestFiles {
         assertEquals(gm1, gm2);
 
         assertTrue(FileUtils.contentEquals(new File("target/tmpJunit/SWLMV2.1.xml"), new File("target/tmpJunit/SWLMV2.xml")));
+    }
+    
+    //Cleaning tmp folder
+    @AfterEach
+    public void deleteOutputFile() throws IOException, InterruptedException {
+        FileUtils.deleteQuietly(new File("target/tmpJunit/"));
     }
 }


### PR DESCRIPTION
Setting file on readonly to avoid hash change on file opening