### PR TITLE
Improve build

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -20,11 +20,11 @@
 *.properties    text
 *.sh            text
 *.tld           text
-# *.txt           text
 *.tag           text
 *.tagx          text
 *.xml           text
 *.yml           text
+**/test/resources/** -text
 
 # These files are binary and should be left untouched
 # (binary is a macro for -text -diff)

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <project.minorVersion>10</project.minorVersion>
         <!--Libraries-->
         <java-libpst.version>0.9.5-VITAM</java-libpst.version>
-        <droid.version>6.5-VITAM</droid.version>
+        <droid.version>6.5</droid.version>
         <commons-cli.version>1.4</commons-cli.version>
         <jackson.version>2.9.9</jackson.version>
         <xerces-xsd11.version>2.12-beta-r1667115</xerces-xsd11.version>


### PR DESCRIPTION
- Use the standard 6.5 DROID version, as the mandatory improvements for sedatools (java 11 support and some visibility changes in the libraries) have been integrated (May 2020)
- Change repo gitattributes to avoid git line endings conversions on test samples, whatever is the global git autocrlf parameter. All tests are OK when building on Windows.