### PR TITLE
First step to Seda2.2

### DIFF
--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/frame/PrefsDialog.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/frame/PrefsDialog.java
@@ -28,13 +28,21 @@
 package fr.gouv.vitam.tools.resip.frame;
 
 import fr.gouv.vitam.tools.resip.app.ResipGraphicApp;
+import fr.gouv.vitam.tools.resip.data.Work;
 import fr.gouv.vitam.tools.resip.parameters.*;
+import fr.gouv.vitam.tools.resip.threads.ChangeSeda2VersionThread;
+import fr.gouv.vitam.tools.resip.threads.CheckProfileThread;
 import fr.gouv.vitam.tools.resip.utils.ResipException;
 import fr.gouv.vitam.tools.resip.utils.ResipLogger;
+import fr.gouv.vitam.tools.sedalib.core.DataObjectPackage;
+import fr.gouv.vitam.tools.sedalib.core.Seda2Version;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger;
 
 import javax.swing.*;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.DocumentFilter;
+import javax.xml.crypto.Data;
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.io.IOException;
@@ -42,7 +50,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import static fr.gouv.vitam.tools.resip.app.ResipGraphicApp.OK_DIALOG;
+import static fr.gouv.vitam.tools.resip.utils.ResipLogger.getGlobalLogger;
 import static fr.gouv.vitam.tools.sedalib.inout.exporter.DataObjectPackageToCSVMetadataExporter.*;
+import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.GLOBAL;
+import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.doProgressLogWithoutInterruption;
 import static java.awt.event.ItemEvent.DESELECTED;
 import static java.awt.event.ItemEvent.SELECTED;
 
@@ -93,6 +105,7 @@ public class PrefsDialog extends JDialog {
     private JTextArea metadataFilterTextArea;
     private JCheckBox metadataFilterCheckBox;
 
+    private JRadioButton seda2Version1RadioButton;
     private JTextField dupMaxTextField;
     private JRadioButton structuredInterfaceRadioButton;
     private JCheckBox debugModeCheckBox;
@@ -950,8 +963,8 @@ public class PrefsDialog extends JDialog {
         tabbedPane.addTab("Traitement/Interface", new ImageIcon(getClass().getResource("/icon/edit-find-replace.png")),
                 treatmentParametersPanel, null);
         GridBagLayout gbl_treatmentParametersPanel = new GridBagLayout();
-        gbl_treatmentParametersPanel.rowHeights = new int[]{0, 0, 0, 0, 0, 0,0};
-        gbl_treatmentParametersPanel.rowWeights = new double[]{0, 0, 0, 0, 0,0, 1.0};
+        gbl_treatmentParametersPanel.rowHeights = new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0};
+        gbl_treatmentParametersPanel.rowWeights = new double[]{0, 0, 0, 0, 0, 0, 0, 0, 1.0};
         treatmentParametersPanel.setLayout(gbl_treatmentParametersPanel);
 
         JLabel workDirLabel = new JLabel("Répertoire de travail");
@@ -1028,6 +1041,44 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
         treatmentParametersPanel.add(dupMaxTextField, gbc);
 
+        JLabel sedaVersionLabel = new JLabel("Version du Standard d'Echange utilisé (SEDA)");
+        sedaVersionLabel.setFont(MainWindow.BOLD_LABEL_FONT);
+        gbc = new GridBagConstraints();
+        gbc.gridwidth = 3;
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.weightx = 1.0;
+        gbc.anchor = GridBagConstraints.NORTHWEST;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.gridx = 0;
+        gbc.gridy = 4;
+        treatmentParametersPanel.add(sedaVersionLabel, gbc);
+
+        seda2Version1RadioButton = new JRadioButton("SEDA 2.1");
+        gbc = new GridBagConstraints();
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.insets = new Insets(0, 0, 5, 5);
+        gbc.gridx = 1;
+        gbc.gridy = 5;
+        treatmentParametersPanel.add(seda2Version1RadioButton, gbc);
+
+        JRadioButton seda2Version2RadioButton = new JRadioButton("SEDA 2.2");
+        gbc = new GridBagConstraints();
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.insets = new Insets(0, 0, 5, 5);
+        gbc.gridx = 2;
+        gbc.gridy = 5;
+        treatmentParametersPanel.add(seda2Version2RadioButton, gbc);
+
+        ButtonGroup seda2VersionButtonGroup = new ButtonGroup();
+        seda2VersionButtonGroup.add(seda2Version1RadioButton);
+        seda2VersionButtonGroup.add(seda2Version2RadioButton);
+        seda2VersionButtonGroup.clearSelection();
+        if (tp.getSeda2Version() == 1)
+            seda2Version1RadioButton.setSelected(true);
+        else
+            seda2Version2RadioButton.setSelected(true);
+
+
         JLabel interfaceLabel = new JLabel("Interface");
         interfaceLabel.setFont(MainWindow.BOLD_LABEL_FONT);
         gbc = new GridBagConstraints();
@@ -1037,7 +1088,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.gridx = 0;
-        gbc.gridy = 4;
+        gbc.gridy = 6;
         treatmentParametersPanel.add(interfaceLabel, gbc);
 
         JLabel interfaceTypeLabel = new JLabel("Interface par défaut:");
@@ -1045,7 +1096,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.EAST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 0;
-        gbc.gridy = 5;
+        gbc.gridy = 7;
         treatmentParametersPanel.add(interfaceTypeLabel, gbc);
 
         structuredInterfaceRadioButton = new JRadioButton("Structurée");
@@ -1053,7 +1104,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 1;
-        gbc.gridy = 5;
+        gbc.gridy = 7;
         treatmentParametersPanel.add(structuredInterfaceRadioButton, gbc);
 
         JRadioButton classicInterfaceRadioButton = new JRadioButton("XML-expert");
@@ -1061,7 +1112,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 2;
-        gbc.gridy = 5;
+        gbc.gridy = 7;
         treatmentParametersPanel.add(classicInterfaceRadioButton, gbc);
 
         ButtonGroup interfaceTypeButtonGroup = new ButtonGroup();
@@ -1073,22 +1124,21 @@ public class PrefsDialog extends JDialog {
         else
             classicInterfaceRadioButton.setSelected(true);
 
-
         JLabel debugModeLabel = new JLabel("Mode débug actif:");
         gbc = new GridBagConstraints();
-        gbc.anchor = GridBagConstraints.EAST;
+        gbc.anchor = GridBagConstraints.NORTHEAST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 0;
-        gbc.gridy = 6;
+        gbc.gridy = 8;
         treatmentParametersPanel.add(debugModeLabel, gbc);
 
         debugModeCheckBox = new JCheckBox("");
         debugModeCheckBox.setSelected(ip.isDebugFlag());
         gbc = new GridBagConstraints();
-        gbc.anchor = GridBagConstraints.WEST;
+        gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 1;
-        gbc.gridy = 6;
+        gbc.gridy = 8;
         treatmentParametersPanel.add(debugModeCheckBox, gbc);
 
         // Buttons
@@ -1135,7 +1185,7 @@ public class PrefsDialog extends JDialog {
     private void buttonOk() {
         if (!extractFromDialog())
             return;
-        returnValue = ResipGraphicApp.OK_DIALOG;
+        returnValue = OK_DIALOG;
         setVisible(false);
     }
 
@@ -1164,7 +1214,7 @@ public class PrefsDialog extends JDialog {
                     "Erreur", UserInteractionDialog.ERROR_DIALOG,
                     null);
             ResipLogger.getGlobalLogger().log(ResipLogger.ERROR,
-                    "Resip.GraphicApp: Erreur fatale, impossible de sélectionner sur le disque",e);
+                    "Resip.GraphicApp: Erreur fatale, impossible de sélectionner sur le disque", e);
         }
     }
 
@@ -1239,6 +1289,55 @@ public class PrefsDialog extends JDialog {
             return false;
         }
         tp.setDupMax(tmp);
+
+        int toSeda2Version = (seda2Version1RadioButton.isSelected() ? 1 : 2);
+        if ((tp.getSeda2Version() != toSeda2Version) && (ResipGraphicApp.getTheApp().currentWork != null)) {
+            if (UserInteractionDialog.getUserAnswer(this.owner,
+                    "Attention, un SIP est ouvert et vous changez de version de SEDA2.x\n" +
+                            "Voulez-vous essayer de le convertir?",
+                    "Confirmation", UserInteractionDialog.WARNING_DIALOG,
+                    null) != OK_DIALOG)
+                return false;
+            else {
+                DataObjectPackage dop = ResipGraphicApp.getTheApp().currentWork.getDataObjectPackage();
+                InOutDialog inOutDialog = new InOutDialog(this.owner, "Conversion vers le schéma SEDA 2." + toSeda2Version);
+                ChangeSeda2VersionThread changeSeda2VersionThread = new ChangeSeda2VersionThread(toSeda2Version, dop, inOutDialog);
+                try {
+                    changeSeda2VersionThread.execute();
+                    inOutDialog.setVisible(true);
+                    while (!changeSeda2VersionThread.isDone()) Thread.sleep(100);
+                }
+                catch (Exception e) {
+                    UserInteractionDialog.getUserAnswer(this.owner,
+                            "Impossible de faire la conversion vers le schéma SEDA 2." +
+                                toSeda2Version +"\n->" + e.getMessage(),
+                            "Erreur", UserInteractionDialog.ERROR_DIALOG,
+                            null);
+                    getGlobalLogger().log(ResipLogger.ERROR, "resip.graphicapp: erreur fatale, impossible de faire l'import",e);
+                    return false;
+                }
+                if (changeSeda2VersionThread.convertedDop == null) {
+                    inOutDialog.setVisible(true);
+                    UserInteractionDialog.getUserAnswer(this.owner,
+                            "Impossible de faire la conversion vers le schéma SEDA 2." +
+                                    toSeda2Version +"\n" +
+                                    "Fermez cet objet avant de changer le schéma SEDA utilisé\n->"
+                                    + changeSeda2VersionThread.exitThrowable,
+                            "Erreur", UserInteractionDialog.ERROR_DIALOG,
+                            null);
+                    getGlobalLogger().log(ResipLogger.ERROR, "resip.graphicapp: erreur fatale, impossible de faire la " +
+                            "conversion vers le schéma SEDA 2." + toSeda2Version, changeSeda2VersionThread.exitThrowable);
+                    return false;
+                }
+                ResipGraphicApp.getTheApp().currentWork.setDataObjectPackage(changeSeda2VersionThread.convertedDop);
+                ResipGraphicApp.getTheWindow().load();
+            }
+        }
+        tp.setSeda2Version((seda2Version1RadioButton.isSelected() ? 1 : 2));
+        try {
+            Seda2Version.setSeda2Version(tp.getSeda2Version());
+        } catch (SEDALibException ignored) {
+        }
 
         ip.setStructuredMetadataEditionFlag(structuredInterfaceRadioButton.isSelected());
         ip.setDebugFlag(debugModeCheckBox.isSelected());

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/parameters/TreatmentParameters.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/parameters/TreatmentParameters.java
@@ -51,6 +51,11 @@ public class TreatmentParameters {
     int dupMax;
 
     /**
+     * The SEDA2 subversion.
+     */
+    int seda2Version;
+
+    /**
      * Instantiates a new creation context.
      */
     public TreatmentParameters() {
@@ -87,6 +92,12 @@ public class TreatmentParameters {
         catch (NumberFormatException e){
             dupMax=1000;
         }
+        try {
+            seda2Version=Integer.parseInt(prefs.getPrefProperties().getProperty("treatmentParameters.seda2Version","1"));
+        }
+        catch (NumberFormatException e){
+            seda2Version=1;
+        }
     }
 
     /**
@@ -100,6 +111,7 @@ public class TreatmentParameters {
             prefs.getPrefProperties().setProperty("treatmentParameters.categories."+canonizeCategoryName(e.getKey()),String.join("|",e.getValue()));
         }
         prefs.getPrefProperties().setProperty("treatmentParameters.dupMax", Integer.toString(dupMax));
+        prefs.getPrefProperties().setProperty("treatmentParameters.seda2Version", Integer.toString(seda2Version));
     }
 
     /**
@@ -149,6 +161,7 @@ public class TreatmentParameters {
         formatByCategoryMap.put("Non connu",Arrays.asList("UNKNOWN"));
         formatByCategoryMap.put("Autres...",Arrays.asList("Other"));
         dupMax=1000;
+        seda2Version=1;
     }
 
     // Getters and setters
@@ -188,4 +201,24 @@ public class TreatmentParameters {
     public void setDupMax(int dupMax) {
         this.dupMax = dupMax;
     }
+
+    /**
+     * Gets seda version.
+     *
+     * @return the seda2 version
+     */
+    public int getSeda2Version() {
+        return seda2Version;
+    }
+
+    /**
+     * Sets seda2 version.
+     *
+     * @param sedaVersion the seda2 version
+     */
+    public void setSeda2Version(int sedaVersion) {
+        this.seda2Version = sedaVersion;
+    }
+
+
 }

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/SEDAObjectEditorConstants.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/SEDAObjectEditorConstants.java
@@ -250,6 +250,11 @@ public class SEDAObjectEditorConstants {
         translateMap.put("RepositoryObjectPID", "ID-Objet-SAE");
         translateMap.put("ExternalReference", "ID-externe");
 
+        // LinkingAgentIdentifier subfields
+        translateMap.put("LinkingAgentIdentifierType", "Type d'indentifiant");
+        translateMap.put("LinkingAgentIdentifierValue", "Valeur d'identifiant");
+        translateMap.put("LinkingAgentRole", "Rôle");
+
         // Event subfields
         translateMap.put("EventIdentifier", "Identifiant");
         translateMap.put("EventTypeCode", "Code de type");
@@ -260,6 +265,7 @@ public class SEDAObjectEditorConstants {
         translateMap.put("OutcomeDetail", "Détail du résultat");
         translateMap.put("OutcomeDetailMessage", "Message de résultat");
         translateMap.put("EventDetailData", "Détail technique");
+        translateMap.put("LinkingAgentIdentifier", "Agent répertorié");
 
         // Signature all subfields
         translateMap.put("SigningTime", "Date de signature");

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/threads/CheckEndDateThread.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/threads/CheckEndDateThread.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.GLOBAL;
 import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.doProgressLogWithoutInterruption;
 
-public class CheckEndDateThread  extends SwingWorker<String, InOutDialog> {
+public class CheckEndDateThread  extends SwingWorker<String, String> {
     private final VerifyDateDialog verifyDateDialog;
     //run output
     private Throwable exitThrowable;

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/ArchiveTransfer.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/ArchiveTransfer.java
@@ -170,6 +170,7 @@ public class ArchiveTransfer {
         try {
             xmlWriter.writeEndElement();
             xmlWriter.writeEndDocument();
+            xmlWriter.flush();
         } catch (XMLStreamException e) {
             throw new SEDALibException("Erreur d'écriture XML de la cloture du manifest", e);
         }

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackage.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackage.java
@@ -1016,8 +1016,9 @@ public class DataObjectPackage {
             xmlWriter.writeEndElement();
             xmlWriter.writeRawXMLBlockIfNotEmpty(managementMetadataXmlData);
             xmlWriter.writeEndElement();
+            xmlWriter.flush();
         } catch (XMLStreamException | SEDALibException e) {
-            throw new SEDALibException("Erreur d'écriture XML des métadonnées des ArchiveUnits", e);
+            throw new SEDALibException("Erreur d'écriture XML des métadonnées dans le DataObjectPackage", e);
         }
         doProgressLog(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_GROUP, "sedalib: " + getNextInOutCounter() +
                 " métadonnées ArchiveUnit exportées dans le DataObjectPackage", null);
@@ -1050,8 +1051,7 @@ public class DataObjectPackage {
      *
      * @param xmlReader             the SEDAXMLEventReader reading the SEDA manifest
      * @param dataObjectPackage     the DataObjectPackage to be completed
-     * @param rootDir               the directory where the BinaryDataObject files are
-     *                              exported
+     * @param rootDir               the directory of the BinaryDataObject files
      * @param sedaLibProgressLogger the progress logger or null if no progress log expected
      * @throws SEDALibException     if the XML can't be read or SEDA scheme is not
      *                              respected

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
@@ -26,21 +26,21 @@ public final class Seda2Version {
     /**
      * For Seda2.1 SEDA2_1=1
      */
-    public final static int SEDA2_1 = 1;
+    public static final int SEDA2_1 = 1;
     /**
      * For Seda2.2 SEDA2_2=2
      */
-    public final static int SEDA2_2 = 2;
+    public static final int SEDA2_2 = 2;
     /**
      * Max Seda2.x supported version MAX_SUPPORTED_VERSION=2
      */
-    public final static int MAX_SUPPORTED_VERSION = 2;
+    public static final int MAX_SUPPORTED_VERSION = 2;
 
     /**
      * SEDA2 convention used for all lib processing
      * Warning: usage for different SEDA2 versions is not possible in parallel process!
      */
-    private static int seda2Version = SEDA2_1;
+    private static int globalSeda2Version = SEDA2_1;
 
     /**
      * Gets Seda2 version.
@@ -48,7 +48,7 @@ public final class Seda2Version {
      * @return the Seda2 version
      */
     public static int getSeda2Version() {
-        return seda2Version;
+        return globalSeda2Version;
     }
 
     /**
@@ -57,7 +57,11 @@ public final class Seda2Version {
      * @return the Seda2 version string
      */
     public static String getSeda2VersionString() {
-        return "Seda2." + seda2Version;
+        return "Seda2." + globalSeda2Version;
+    }
+
+    private Seda2Version() {
+        throw new IllegalStateException("Utility class");
     }
 
     /**
@@ -67,7 +71,7 @@ public final class Seda2Version {
      * @return the boolean
      */
     public static boolean isSupportedSeda2Version(int newSeda2Version) {
-        switch (seda2Version) {
+        switch (newSeda2Version) {
             case SEDA2_1:
             case SEDA2_2:
                 return true;
@@ -84,7 +88,7 @@ public final class Seda2Version {
      */
     public static void setSeda2Version(int newSeda2Version) throws SEDALibException {
         if (isSupportedSeda2Version(newSeda2Version))
-            seda2Version = newSeda2Version;
+            globalSeda2Version = newSeda2Version;
         else
             throw new SEDALibException("Unknown Seda2." + newSeda2Version + " version");
     }
@@ -93,10 +97,12 @@ public final class Seda2Version {
      * Convert à DataObjectPackage to Seda2 version using XML as pivot format.
      * <P>Warning: this very special function is mostly done to be used in interactive program like Resip.</P>
      *
-     * @param dataObjectPackage the DataObjectPackage
-     * @param toSeda2Version    the destination Seda2 version
+     * @param dataObjectPackage     the DataObjectPackage
+     * @param toSeda2Version        the destination Seda2 version
+     * @param sedaLibProgressLogger the seda lib progress logger
      * @return the converted DataObjectPackage
-     * @throws SEDALibException if not supported version or if conversion through XML is not possible
+     * @throws SEDALibException     if not supported version or if conversion through XML is not possible
+     * @throws InterruptedException the interrupted exception
      */
     public static DataObjectPackage convertToSeda2Version(DataObjectPackage dataObjectPackage, int toSeda2Version, SEDALibProgressLogger sedaLibProgressLogger)
             throws SEDALibException, InterruptedException {
@@ -114,8 +120,8 @@ public final class Seda2Version {
         try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
              SEDAXMLStreamWriter oxsw = new SEDAXMLStreamWriter(baos, IndentXMLTool.STANDARD_INDENT)) {
             dataObjectPackage.toSedaXml(oxsw, true, sedaLibProgressLogger);
-            xmlForm = baos.toString("UTF-8");
-        } catch (XMLStreamException | IOException | InterruptedException e) {
+            xmlForm = baos.toString(StandardCharsets.UTF_8);
+        } catch (XMLStreamException | IOException e) {
             throw new SEDALibException("Echec d'écriture XML du DataObjectPackage dans la version seda2." + originSeda2Version, e);
         }
         setSeda2Version(toSeda2Version);
@@ -125,7 +131,7 @@ public final class Seda2Version {
              SEDAXMLEventReader ixer = new SEDAXMLEventReader(bais, true)) {
             ixer.xmlReader.nextEvent(); // drop the StartDocument event
             result = DataObjectPackage.fromSedaXml(ixer, "unknown", sedaLibProgressLogger);
-        } catch (XMLStreamException | IOException | InterruptedException e) {
+        } catch (XMLStreamException | IOException e) {
             setSeda2Version(originSeda2Version);
             throw new SEDALibException("Echec de conversion à travers XML du DataObjectPackage dans la version seda2." + toSeda2Version, e);
         }

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
@@ -18,7 +18,8 @@ import java.util.Map;
  * <ul><li>only the ontology and a the xsd declaration are different, not the messages structure</li>
  * <li>the Seda2 version has not to be changed when previous version objects exist</li></ul>
  * The global Seda2 version is used in all SEDAMetadata class to adapt to ontology used.
- * <P>Warning: there is a very special function ({@link #convertToSeda2Version(DataObjectPackage, int, SedaLibProgressLogger) convertToSeda2Version}) implemented to convert a DataObjectPackage to another Seda2 version.
+ * <P>Warning: there is a very special method ({@link #convertToSeda2Version(DataObjectPackage, int, SEDALibProgressLogger)})
+ * implemented to convert a DataObjectPackage to another Seda2 version.
  * This is mostly done to be used in interactive program like Resip.</P>
  */
 public final class Seda2Version {

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
@@ -1,0 +1,137 @@
+package fr.gouv.vitam.tools.sedalib.core;
+
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger;
+import fr.gouv.vitam.tools.sedalib.xml.IndentXMLTool;
+import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLEventReader;
+import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLStreamWriter;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * The Seda2 version management class, make it possible to use different Seda2 version if:
+ * <ul><li>only the ontology and a the xsd declaration are different, not the messages structure</li>
+ * <li>the Seda2 version has not to be changed when previous version objects exist</li></ul>
+ * The global Seda2 version is used in all SEDAMetadata class to adapt to ontology used.
+ * <P>Warning: there is a very special function ({@link #convertToSeda2Version(DataObjectPackage, int, SedaLibProgressLogger) convertToSeda2Version}) implemented to convert a DataObjectPackage to another Seda2 version.
+ * This is mostly done to be used in interactive program like Resip.</P>
+ */
+public final class Seda2Version {
+    /**
+     * For Seda2.1 SEDA2_1=1
+     */
+    public final static int SEDA2_1 = 1;
+    /**
+     * For Seda2.2 SEDA2_2=2
+     */
+    public final static int SEDA2_2 = 2;
+    /**
+     * Max Seda2.x supported version MAX_SUPPORTED_VERSION=2
+     */
+    public final static int MAX_SUPPORTED_VERSION = 2;
+
+    /**
+     * SEDA2 convention used for all lib processing
+     * Warning: usage for different SEDA2 versions is not possible in parallel process!
+     */
+    private static int seda2Version = SEDA2_1;
+
+    /**
+     * Gets Seda2 version.
+     *
+     * @return the Seda2 version
+     */
+    public static int getSeda2Version() {
+        return seda2Version;
+    }
+
+    /**
+     * Gets Seda2 version string.
+     *
+     * @return the Seda2 version string
+     */
+    public static String getSeda2VersionString() {
+        return "Seda2." + seda2Version;
+    }
+
+    /**
+     * Is supported Seda2 version boolean.
+     *
+     * @param newSeda2Version the new seda 2 version
+     * @return the boolean
+     */
+    public static boolean isSupportedSeda2Version(int newSeda2Version) {
+        switch (seda2Version) {
+            case SEDA2_1:
+            case SEDA2_2:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Sets Seda2 version.
+     *
+     * @param newSeda2Version the new Seda2 version
+     * @throws SEDALibException if this is not a supported version
+     */
+    public static void setSeda2Version(int newSeda2Version) throws SEDALibException {
+        if (isSupportedSeda2Version(newSeda2Version))
+            seda2Version = newSeda2Version;
+        else
+            throw new SEDALibException("Unknown Seda2." + newSeda2Version + " version");
+    }
+
+    /**
+     * Convert à DataObjectPackage to Seda2 version using XML as pivot format.
+     * <P>Warning: this very special function is mostly done to be used in interactive program like Resip.</P>
+     *
+     * @param dataObjectPackage the DataObjectPackage
+     * @param toSeda2Version    the destination Seda2 version
+     * @return the converted DataObjectPackage
+     * @throws SEDALibException if not supported version or if conversion through XML is not possible
+     */
+    public static DataObjectPackage convertToSeda2Version(DataObjectPackage dataObjectPackage, int toSeda2Version, SEDALibProgressLogger sedaLibProgressLogger)
+            throws SEDALibException, InterruptedException {
+        String xmlForm;
+        DataObjectPackage result;
+        int originSeda2Version = getSeda2Version();
+
+        if (!isSupportedSeda2Version(toSeda2Version))
+            throw new SEDALibException("Unknown Seda2." + toSeda2Version + " version");
+
+        SEDALibProgressLogger.doProgressLog(sedaLibProgressLogger,SEDALibProgressLogger.GLOBAL,
+                "Passage de la version Seda2."+originSeda2Version+" à la version Seda2."+toSeda2Version,null);
+        SEDALibProgressLogger.doProgressLog(sedaLibProgressLogger,SEDALibProgressLogger.STEP,
+                "-> Ecriture XML en version Seda2."+originSeda2Version,null);
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             SEDAXMLStreamWriter oxsw = new SEDAXMLStreamWriter(baos, IndentXMLTool.STANDARD_INDENT)) {
+            dataObjectPackage.toSedaXml(oxsw, true, sedaLibProgressLogger);
+            xmlForm = baos.toString("UTF-8");
+        } catch (XMLStreamException | IOException | InterruptedException e) {
+            throw new SEDALibException("Echec d'écriture XML du DataObjectPackage dans la version seda2." + originSeda2Version, e);
+        }
+        setSeda2Version(toSeda2Version);
+        SEDALibProgressLogger.doProgressLog(sedaLibProgressLogger,SEDALibProgressLogger.STEP,
+                "-> Prise en compte à partir de l'XML généré, vers la version Seda2."+toSeda2Version,null);
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(xmlForm.getBytes(StandardCharsets.UTF_8));
+             SEDAXMLEventReader ixer = new SEDAXMLEventReader(bais, true)) {
+            ixer.xmlReader.nextEvent(); // drop the StartDocument event
+            result = DataObjectPackage.fromSedaXml(ixer, "unknown", sedaLibProgressLogger);
+        } catch (XMLStreamException | IOException | InterruptedException e) {
+            setSeda2Version(originSeda2Version);
+            throw new SEDALibException("Echec de conversion à travers XML du DataObjectPackage dans la version seda2." + toSeda2Version, e);
+        }
+        for (Map.Entry<String, BinaryDataObject> identifiedDataObject : dataObjectPackage.getBdoInDataObjectPackageIdMap().entrySet())
+            result.getBdoInDataObjectPackageIdMap().get(identifiedDataObject.getKey()).setOnDiskPath(identifiedDataObject.getValue().getOnDiskPath());
+        setSeda2Version(originSeda2Version);
+
+        return result;
+    }
+}

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/exporter/DataObjectPackageToCSVMetadataExporter.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/exporter/DataObjectPackageToCSVMetadataExporter.java
@@ -261,7 +261,7 @@ public class DataObjectPackageToCSVMetadataExporter {
 
     // extract and sort headernames by there defined order in composed types
     private List<String> getSortedHeaderNames(List<String> sortedHeaderNames, Set<String> headerNames,
-                                              String prefixHeaderName, String xmlElementName, Class<?> metadataClass) {
+                                              String prefixHeaderName, String xmlElementName, Class<?> metadataClass) throws SEDALibException {
         String currentName = prefixHeaderName + (prefixHeaderName.isEmpty() ? "" : ".") + xmlElementName;
         String infix;
         int maxRank = getMaxRank(headerNames, currentName);

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/content/Event.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/content/Event.java
@@ -51,22 +51,43 @@ public class Event extends ComplexListType {
      * Init metadata map.
      */
     @ComplexListMetadataMap(isExpandable = true)
-    public static final Map<String, ComplexListMetadataKind> metadataMap;
+    public static final Map<String, ComplexListMetadataKind> metadataMap_default;
 
     static {
-        metadataMap = new LinkedHashMap<>();
-        metadataMap.put("EventIdentifier",
+        metadataMap_default = new LinkedHashMap<>();
+        metadataMap_default.put("EventIdentifier",
                 new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventTypeCode", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventType", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventDateTime", new ComplexListMetadataKind(DateTimeType.class, false));
-        metadataMap.put("EventDetail", new ComplexListMetadataKind(StringType.class, true));
-        metadataMap.put("Outcome", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("OutcomeDetail", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("OutcomeDetailMessage",
+        metadataMap_default.put("EventTypeCode", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("EventType", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("EventDateTime", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_default.put("EventDetail", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_default.put("Outcome", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("OutcomeDetail", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("OutcomeDetailMessage",
                 new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventDetailData",
+        metadataMap_default.put("EventDetailData",
                 new ComplexListMetadataKind(StringType.class, false));
+    }
+
+    @ComplexListMetadataMap(isExpandable = true, seda2Version = 2)
+    public static final Map<String, ComplexListMetadataKind> metadataMap_v2;
+
+    static {
+        metadataMap_v2 = new LinkedHashMap<>();
+        metadataMap_v2.put("EventIdentifier",
+                new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventTypeCode", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventType", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventDateTime", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("EventDetail", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("Outcome", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("OutcomeDetail", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("OutcomeDetailMessage",
+                new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventDetailData",
+                new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("LinkingAgentIdentifier",
+                new ComplexListMetadataKind(LinkingAgentIdentifierType.class, true));
     }
 
     /**

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListMetadataMap.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListMetadataMap.java
@@ -5,5 +5,8 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ComplexListMetadataMap {
+    public static int NON_SPECIFIC_SEDA2_VERSION=-1;
+
     boolean isExpandable() default false;
+    int seda2Version() default NON_SPECIFIC_SEDA2_VERSION;
 }

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListType.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListType.java
@@ -28,6 +28,7 @@
 package fr.gouv.vitam.tools.sedalib.metadata.namedtype;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fr.gouv.vitam.tools.sedalib.core.Seda2Version;
 import fr.gouv.vitam.tools.sedalib.metadata.SEDAMetadata;
 import fr.gouv.vitam.tools.sedalib.metadata.content.Gps;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
@@ -46,10 +47,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 
 /**
  * The Class ComplexListType.
@@ -59,19 +57,32 @@ import java.util.List;
 public abstract class ComplexListType extends NamedTypeMetadata {
 
     /**
-     * The Sub type metadata ordered list map.
+     * The analyzed Sub type metadata set.
      */
-    protected static HashMap<Class<?>, List<String>> subTypeMetadataOrderedListMap = new HashMap<>();
+    protected static HashSet<Class<?>> analyzedSubTypeMetadataSet = new HashSet<>();
     /**
-     * The Sub type metadata map map.
+     * The Sub type metadata ordered list map by versions.
      */
-    protected static HashMap<Class<?>, LinkedHashMap<String, ComplexListMetadataKind>> subTypeMetadataMapMap =
-            new HashMap<>();
+    protected static HashMap<Class<?>, List<String>>[] subTypeMetadataOrderedListMap = new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
     /**
-     * The Sub type expandable map.
+     * The Sub type metadata map map by versions.
      */
-    protected static HashMap<Class<?>, Boolean> subTypeNotExpandableMap =
-            new HashMap<>();
+    protected static HashMap<Class<?>, LinkedHashMap<String, ComplexListMetadataKind>>[] subTypeMetadataMapMap =
+            new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
+    /**
+     * The Sub type expandable map by versions.
+     */
+    protected static HashMap<Class<?>, Boolean>[] subTypeNotExpandableMap =
+            new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
+
+    // init empty maps for all versions (index=version+1) and non specific one (index=0)
+    static {
+        for (int i=0;i<Seda2Version.MAX_SUPPORTED_VERSION+2;i++){
+            subTypeMetadataOrderedListMap[i]=new HashMap<>();
+            subTypeMetadataMapMap[i]=new HashMap<>();
+            subTypeNotExpandableMap[i]=new HashMap<>();
+        }
+    }
 
     /**
      * The metadata list.
@@ -377,7 +388,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      * Add metadata from fragments in XML expected form for the SEDA Manifest.
      *
      * @param xmlData the xml data
-     * @throws SEDALibException if the XML can't be read or the SEDA scheme is not                          respected
+     * @throws SEDALibException if the XML can't be read or the SEDA scheme is not respected
      */
     public void addSedaXmlFragments(String xmlData) throws SEDALibException {
         Class<?> metadataClass;
@@ -409,25 +420,36 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     private static void getNewComplexListSubType(Class<?> subClass) throws SEDALibException {
         List<Field> fields = FieldUtils.getFieldsListWithAnnotation(subClass, ComplexListMetadataMap.class);
         if (fields.isEmpty())
-            throw new SEDALibException("Le type " + subClass + " n'a pas de variable annotée @ComplexListMetadataMap accessible");
-        else if (fields.size() > 1)
-            throw new SEDALibException("Le type " + subClass + " a plusieurs variables annotées @ComplexListMetadataMap accessibles (classe ou parents)");
+            throw new SEDALibException("Le type " + subClass +
+                    " n'a pas de variable annotée @ComplexListMetadataMap accessible");
+        else if (fields.size() > Seda2Version.MAX_SUPPORTED_VERSION)
+            throw new SEDALibException("Le type " + subClass +
+                    " a un trop grand nombre de variables annotées @ComplexListMetadataMap accessibles");
 
         Object object;
+        int seda2Version;
+        boolean isExpandable;
         LinkedHashMap<String, ComplexListMetadataKind> metadataMap;
-        try {
-            object = fields.get(0).get(null);
-        } catch (IllegalAccessException e) {
-            throw new SEDALibException("La variable " + fields.get(0) + " annotée @ComplexListMetadataMap du type " + subClass + " ne peut être accédée", e);
+        for (int i = 0; i < fields.size();i++) {
+            try {
+                object = fields.get(i).get(null);
+                seda2Version= fields.get(i).getAnnotation(ComplexListMetadataMap.class).seda2Version();
+                isExpandable= fields.get(i).getAnnotation(ComplexListMetadataMap.class).isExpandable();
+            } catch (IllegalAccessException e) {
+                throw new SEDALibException("La variable " + fields.get(i) + " annotée @ComplexListMetadataMap du type " +
+                        subClass + " pour la version "+(i==-1?"par défaut":i)+" ne peut être accédée", e);
+            }
+            try {
+                metadataMap = (LinkedHashMap<String, ComplexListMetadataKind>) object;
+            } catch (ClassCastException e) {
+                throw new SEDALibException("La variable " + fields.get(i) + " annotée @ComplexListMetadataMap du type " +
+                        subClass + " n'est pas de type LinkedHashMap<String,ComplexListMetadataKind>", e);
+            }
+            subTypeMetadataMapMap[seda2Version+1].put(subClass, metadataMap);
+            subTypeMetadataOrderedListMap[seda2Version+1].put(subClass, new ArrayList<>(metadataMap.keySet()));
+            subTypeNotExpandableMap[seda2Version+1].put(subClass, !isExpandable);
         }
-        try {
-            metadataMap = (LinkedHashMap<String, ComplexListMetadataKind>) object;
-        } catch (ClassCastException e) {
-            throw new SEDALibException("La variable " + fields.get(0) + " annotée @ComplexListMetadataMap du type " + subClass + " n'est pas de type LinkedHashMap<String,ComplexListMetadataKind>", e);
-        }
-        subTypeMetadataMapMap.put(subClass, metadataMap);
-        subTypeMetadataOrderedListMap.put(subClass, new ArrayList<>(metadataMap.keySet()));
-        subTypeNotExpandableMap.put(subClass, !fields.get(0).getAnnotation(ComplexListMetadataMap.class).isExpandable());
+        analyzedSubTypeMetadataSet.add(subClass);
     }
 
     /**
@@ -438,11 +460,11 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      */
     @JsonIgnore
     public List<String> getMetadataOrderedList() throws SEDALibException {
-        List<String> metadataOrderedList = subTypeMetadataOrderedListMap.get(this.getClass());
-        if (metadataOrderedList == null) {
+        if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-            metadataOrderedList = subTypeMetadataOrderedListMap.get(this.getClass());
-        }
+        List<String> metadataOrderedList = subTypeMetadataOrderedListMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        if (metadataOrderedList == null)
+            metadataOrderedList = subTypeMetadataOrderedListMap[0].get(this.getClass());
         return metadataOrderedList;
     }
 
@@ -455,11 +477,11 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      */
     @JsonIgnore
     public HashMap<String, ComplexListMetadataKind> getMetadataMap() throws SEDALibException {
-        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap.get(this.getClass());
-        if (metadataMap == null) {
+        if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-            metadataMap = subTypeMetadataMapMap.get(this.getClass());
-        }
+        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        if (metadataMap == null)
+            metadataMap = subTypeMetadataMapMap[0].get(this.getClass());
         return metadataMap;
     }
 
@@ -469,9 +491,14 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      *
      * @param complexListTypeMetadataClass the complex list type metadata class
      * @return the metadata map
+     * @throws SEDALibException if the @ComplexListMetadataMap annotated static variable doesn't exist or is badly formed
      */
-    public static HashMap<String, ComplexListMetadataKind> getMetadataMap(Class<?> complexListTypeMetadataClass) {
-        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap.get(complexListTypeMetadataClass);
+    public static HashMap<String, ComplexListMetadataKind> getMetadataMap(Class<?> complexListTypeMetadataClass) throws SEDALibException {
+        if (!analyzedSubTypeMetadataSet.contains(complexListTypeMetadataClass))
+            getNewComplexListSubType(complexListTypeMetadataClass);
+        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[Seda2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
+        if (metadataMap == null)
+            metadataMap = subTypeMetadataMapMap[0].get(complexListTypeMetadataClass);
         return metadataMap;
     }
 
@@ -483,12 +510,12 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      */
     @JsonIgnore
     public boolean isNotExpendable() throws SEDALibException {
-        Boolean isNotExpandable = subTypeNotExpandableMap.get(this.getClass());
-        if (isNotExpandable == null) {
+        if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-            isNotExpandable = subTypeNotExpandableMap.get(this.getClass());
-        }
-        return isNotExpandable;
+        Boolean isNotExpandable = subTypeNotExpandableMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        if (isNotExpandable == null)
+            isNotExpandable = subTypeNotExpandableMap[0].get(this.getClass());
+         return isNotExpandable;
     }
 
     /**
@@ -496,9 +523,15 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      *
      * @param complexListTypeMetadataClass the complex list type metadata class
      * @return true, if is not expendable
+     * @throws SEDALibException if the @ComplexListMetadataMap annotated static variable doesn't exist or is badly formed
      */
-    public static Boolean isNotExpendable(Class<?> complexListTypeMetadataClass) {
-        return subTypeNotExpandableMap.get(complexListTypeMetadataClass);
+    public static Boolean isNotExpendable(Class<?> complexListTypeMetadataClass) throws SEDALibException {
+        if (!analyzedSubTypeMetadataSet.contains(complexListTypeMetadataClass))
+            getNewComplexListSubType(complexListTypeMetadataClass);
+        Boolean isNotExpandable = subTypeNotExpandableMap[Seda2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
+        if (isNotExpandable == null)
+            isNotExpandable = subTypeNotExpandableMap[0].get(complexListTypeMetadataClass);
+        return isNotExpandable;
     }
 
     /**
@@ -534,9 +567,10 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      *
      * @param metadataName the metadata name
      * @return the boolean
+     * @throws SEDALibException if the @ComplexListMetadataMap annotated static variable doesn't exist or is badly formed
      */
-    public boolean isAMultiValuedMetadata(String metadataName) {
-        ComplexListMetadataKind clmk = subTypeMetadataMapMap.get(this.getClass()).get(metadataName);
+    public boolean isAMultiValuedMetadata(String metadataName) throws SEDALibException {
+        ComplexListMetadataKind clmk = getMetadataMap().get(metadataName);
         if (clmk == null)
             return true;
         return clmk.isMany();

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/LinkingAgentIdentifierType.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/LinkingAgentIdentifierType.java
@@ -1,0 +1,52 @@
+package fr.gouv.vitam.tools.sedalib.metadata.namedtype;
+
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LinkingAgentIdentifierType extends ComplexListType {
+    /**
+     * Init metadata map.
+     */
+    @ComplexListMetadataMap(seda2Version = 2)
+    public static final Map<String, ComplexListMetadataKind> metadataMap;
+
+    static {
+        metadataMap = new LinkedHashMap<>();
+        metadataMap.put("LinkingAgentIdentifierType", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap.put("LinkingAgentIdentifierValue", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap.put("LinkingAgentRole", new ComplexListMetadataKind(StringType.class, false));
+    }
+
+    /**
+     * Instantiates a new linking agent identifier type.
+     *
+     * @param elementName the element name
+     */
+    public LinkingAgentIdentifierType(String elementName) {
+        super(elementName);
+    }
+
+    /**
+     * Instantiates a new linking agent identifier with type, value and role.
+     *
+     * @param elementName                 the element name
+     * @param linkingAgentIdentifierType  the linking agent identifier type
+     * @param linkingAgentIdentifierValue the linking agent identifier value
+     * @param linkingAgentRole            the linking agent role
+     * @throws SEDALibException if sub elements construction is not possible (not supposed to occur)
+     */
+    public LinkingAgentIdentifierType(String elementName,
+                                      String linkingAgentIdentifierType,
+                                      String linkingAgentIdentifierValue,
+                                      String linkingAgentRole) throws SEDALibException{
+        super(elementName);
+        if (linkingAgentIdentifierType!=null)
+            addNewMetadata("LinkingAgentIdentifierType", linkingAgentIdentifierType);
+        if (linkingAgentIdentifierValue!=null)
+            addNewMetadata("LinkingAgentIdentifierValue", linkingAgentIdentifierValue);
+        if (linkingAgentRole!=null)
+            addNewMetadata("LinkingAgentRole", linkingAgentRole);
+    }
+}

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/package-info.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/package-info.java
@@ -1,5 +1,7 @@
 /**
  * Package for SEDA structure objects (DataObjectPackage, ArchiveUnits and DataObjects) metadata with serialization to and
- * deserilization from XML
+ * deserilization from XML.<P>
+ * <B>Warning</B>: It's possible to choose the SEDA2.x version used but this library is not compliant for parallel use with objects in different versions.
+ *
  */
 package fr.gouv.vitam.tools.sedalib.metadata;

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/xml/IndentXMLTool.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/xml/IndentXMLTool.java
@@ -24,7 +24,7 @@
  * <p>
  * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
  * accept its terms.
- */
+ **/
 package fr.gouv.vitam.tools.sedalib.xml;
 
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
@@ -159,7 +159,7 @@ public class IndentXMLTool {
 
         DocumentBuilder appDocumentBuilder;
         try {
-            appDocumentBuilder = dbf.newDocumentBuilder();
+            appDocumentBuilder = dbf.newDocumentBuilder(); // NOSONAR no Doctype risk as all is encapsulated in a <INDENT> tag
             Document doc = appDocumentBuilder.parse(new InputSource(new StringReader("<INDENT>" + xml + "</INDENT>")));
             XPath xPath = xpf.newXPath();
             NodeList nodeList = (NodeList) xPath.evaluate("//text()[normalize-space()='']", doc, XPathConstants.NODESET);
@@ -180,16 +180,16 @@ public class IndentXMLTool {
             while (result.startsWith("\n"))
                 result = result.substring(1);
 
-            Scanner s = new Scanner(result);
             StringBuilder sb = new StringBuilder();
             String tmp;
-            while (s.hasNextLine()) {
-                tmp = s.nextLine();
-                if (tmp.startsWith(indentElement))
-                    tmp = tmp.substring(indentLength);
-                sb.append(tmp).append('\n');
+            try (Scanner s = new Scanner(result)) {
+                while (s.hasNextLine()) {
+                    tmp = s.nextLine();
+                    if (tmp.startsWith(indentElement) && tmp.trim().startsWith("<"))
+                        tmp = tmp.substring(indentLength);
+                    sb.append(tmp).append('\n');
+                }
             }
-            s.close();
             if (sb.length() > 1)
                 sb.setLength(sb.length() - 1);
             return sb.toString();

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/Seda2VersionTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/Seda2VersionTest.java
@@ -1,0 +1,144 @@
+package fr.gouv.vitam.tools.sedalib.core;
+
+import fr.gouv.vitam.tools.sedalib.metadata.SEDAMetadata;
+import fr.gouv.vitam.tools.sedalib.metadata.content.*;
+import fr.gouv.vitam.tools.sedalib.metadata.namedtype.*;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLEventReader;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class Seda2VersionTest {
+    @Test
+        // Test the SEDA2.1 and 2.2 construct from xml string (fromSedaXML)
+    void testSeda2VersionComplianceTest() throws SEDALibException {
+        // Given
+        Seda2Version.setSeda2Version(1);
+        Content c = new Content();
+
+        String xmlFragments="  <Event>\n" +
+                "    <EventIdentifier>AUT-234452</EventIdentifier>\n" +
+                "    <EventTypeCode>Autorisation</EventTypeCode>\n" +
+                "    <EventDateTime>2104-05-31T01:00:00</EventDateTime>\n" +
+                "    <Outcome>OK</Outcome>\n" +
+                "    <AnyThing>OK</AnyThing>\n" +
+                "    <LinkingAgentIdentifier>\n" +
+                "      <LinkingAgentIdentifierType>Matricule</LinkingAgentIdentifierType>\n" +
+                "      <LinkingAgentIdentifierValue>123456789</LinkingAgentIdentifierValue>\n" +
+                "      <LinkingAgentRole>Archiviste</LinkingAgentRole>\n" +
+                "    </LinkingAgentIdentifier>\n" +
+                "  </Event>\n";
+        c.addSedaXmlFragments(xmlFragments);
+
+        // Test XML export depending on Seda2 version
+
+        String cOut = c.toString();
+
+        // Then in Seda2.1 version the LinkingAgentIdentifier is in expansion field and order is kept the same
+
+        String testOut = "<Content>\n" +
+                xmlFragments +
+                "</Content>";
+        assertThat(cOut).isEqualTo(testOut);
+
+        // But in Seda2.2 version the LinkingAgentIdentifier is a recognized XML element and re-ordered before the
+        // expansion field
+        Seda2Version.setSeda2Version(2);
+        c = new Content();
+        c.addSedaXmlFragments(xmlFragments);
+        cOut = c.toString();
+        assertThat(cOut).isNotEqualTo(testOut);
+    }
+
+    @Test
+        // Test the SEDA2.1 to and from 2.2 conversion
+    void testSeda2VersionConversionTest() throws SEDALibException {
+        // Given
+        Seda2Version.setSeda2Version(1);
+        String xmlFragments="    <DataObjectPackage>\n" +
+                "    <DescriptiveMetadata>\n" +
+                "      <ArchiveUnit id=\"ID10\">\n" +
+                "        <Content>\n" +
+                "          <DescriptionLevel>RecordGrp</DescriptionLevel>\n" +
+                "          <Title>Nouvelle ArchiveUnit</Title>\n" +
+                "          <Description>Ce test est pour voir ce qui se passe\n" +
+                "                  après 20 espaces</Description>\n" +
+                "          <Event>\n" +
+                "            <EventType>TyE</EventType>\n" +
+                "            <EventDateTime>2022-05-10T00:00:00</EventDateTime>\n" +
+                "            <EventDetail>DetE</EventDetail>\n" +
+                "            <LinkingAgentIdentifier>\n" +
+                "              <LinkingAgentIdentifierType>ty</LinkingAgentIdentifierType>\n" +
+                "              <LinkingAgentIdentifierValue>va</LinkingAgentIdentifierValue>\n" +
+                "              <LinkingAgentRole>ro</LinkingAgentRole>\n" +
+                "            </LinkingAgentIdentifier>\n" +
+                "            <Other>123</Other>\n" +
+                "          </Event>\n" +
+                "        </Content>\n" +
+                "      </ArchiveUnit>\n" +
+                "    </DescriptiveMetadata>\n" +
+                "    <ManagementMetadata>\n" +
+                "      <AcquisitionInformation>Acquisition Information</AcquisitionInformation>\n" +
+                "      <LegalStatus>Public Archive</LegalStatus>\n" +
+                "      <OriginatingAgencyIdentifier>Service_producteur</OriginatingAgencyIdentifier>\n" +
+                "      <SubmissionAgencyIdentifier>Service_versant</SubmissionAgencyIdentifier>\n" +
+                "    </ManagementMetadata>\n" +
+                "  </DataObjectPackage>";
+
+        // Test the import in Seda2.1
+
+        DataObjectPackage dop=null;
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(xmlFragments.getBytes(StandardCharsets.UTF_8));
+             SEDAXMLEventReader xmlReader = new SEDAXMLEventReader(bais)) {
+            xmlReader.nextUsefullEvent();
+            dop=DataObjectPackage.fromSedaXml(xmlReader, "", null);
+        } catch (XMLStreamException | IOException | InterruptedException e) {
+            assertThat(e).isNull();
+        }
+
+        Content c=dop.getArchiveUnitById("ID10").getContent();
+        boolean foundLinking=false;
+        for (SEDAMetadata sm : c.metadataList) {
+            if (sm.getXmlElementName().equals("Event")){
+                Event event=(Event) sm;
+                for (SEDAMetadata osm : event.metadataList){
+                    if (osm instanceof LinkingAgentIdentifierType)
+                        foundLinking=true;
+                }
+            }
+        }
+        assertThat(foundLinking).isFalse();
+
+
+        // Then the Event in ArchiveUnit has a LinkingAgentIdentifierType metadata
+
+        try {
+            dop=Seda2Version.convertToSeda2Version(dop,2,null);
+        } catch (InterruptedException ignored) {
+        }
+        Seda2Version.setSeda2Version(2);
+
+        c=dop.getArchiveUnitById("ID10").getContent();
+        foundLinking=false;
+        for (SEDAMetadata sm : c.metadataList) {
+            if (sm.getXmlElementName().equals("Event")){
+                Event event=(Event) sm;
+                for (SEDAMetadata osm : event.metadataList){
+                    if (osm instanceof LinkingAgentIdentifierType)
+                        foundLinking=true;
+                }
+            }
+        }
+        assertThat(foundLinking).isTrue();
+    }
+}


### PR DESCRIPTION
- sedalib: add the global mechanism for managing other SEDA2 schema versions with different ontologies experimented on Event and LinkingAgentIdentifier (ComplexListType metadata with SEDA2 version depending definition)
- resip: add the SEDA2 version preference in the "Traitement/Interface" tab

Todo: use the global mechanism extend to all the SEDA2.2 differences in ontology
