### PR TITLE
First step to Seda2.2

### DIFF
--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/frame/PrefsDialog.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/frame/PrefsDialog.java
@@ -28,21 +28,17 @@
 package fr.gouv.vitam.tools.resip.frame;
 
 import fr.gouv.vitam.tools.resip.app.ResipGraphicApp;
-import fr.gouv.vitam.tools.resip.data.Work;
 import fr.gouv.vitam.tools.resip.parameters.*;
 import fr.gouv.vitam.tools.resip.threads.ChangeSeda2VersionThread;
-import fr.gouv.vitam.tools.resip.threads.CheckProfileThread;
 import fr.gouv.vitam.tools.resip.utils.ResipException;
 import fr.gouv.vitam.tools.resip.utils.ResipLogger;
 import fr.gouv.vitam.tools.sedalib.core.DataObjectPackage;
-import fr.gouv.vitam.tools.sedalib.core.Seda2Version;
+import fr.gouv.vitam.tools.sedalib.core.SEDA2Version;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
-import fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger;
 
 import javax.swing.*;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.DocumentFilter;
-import javax.xml.crypto.Data;
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.io.IOException;
@@ -53,8 +49,6 @@ import java.util.stream.Collectors;
 import static fr.gouv.vitam.tools.resip.app.ResipGraphicApp.OK_DIALOG;
 import static fr.gouv.vitam.tools.resip.utils.ResipLogger.getGlobalLogger;
 import static fr.gouv.vitam.tools.sedalib.inout.exporter.DataObjectPackageToCSVMetadataExporter.*;
-import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.GLOBAL;
-import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.doProgressLogWithoutInterruption;
 import static java.awt.event.ItemEvent.DESELECTED;
 import static java.awt.event.ItemEvent.SELECTED;
 
@@ -1335,7 +1329,7 @@ public class PrefsDialog extends JDialog {
         }
         tp.setSeda2Version((seda2Version1RadioButton.isSelected() ? 1 : 2));
         try {
-            Seda2Version.setSeda2Version(tp.getSeda2Version());
+            SEDA2Version.setSeda2Version(tp.getSeda2Version());
         } catch (SEDALibException ignored) {
         }
 

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/frame/PrefsDialog.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/frame/PrefsDialog.java
@@ -28,13 +28,21 @@
 package fr.gouv.vitam.tools.resip.frame;
 
 import fr.gouv.vitam.tools.resip.app.ResipGraphicApp;
+import fr.gouv.vitam.tools.resip.data.Work;
 import fr.gouv.vitam.tools.resip.parameters.*;
+import fr.gouv.vitam.tools.resip.threads.ChangeSeda2VersionThread;
+import fr.gouv.vitam.tools.resip.threads.CheckProfileThread;
 import fr.gouv.vitam.tools.resip.utils.ResipException;
 import fr.gouv.vitam.tools.resip.utils.ResipLogger;
+import fr.gouv.vitam.tools.sedalib.core.DataObjectPackage;
+import fr.gouv.vitam.tools.sedalib.core.Seda2Version;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger;
 
 import javax.swing.*;
 import javax.swing.text.AbstractDocument;
 import javax.swing.text.DocumentFilter;
+import javax.xml.crypto.Data;
 import java.awt.*;
 import java.awt.event.ItemEvent;
 import java.io.IOException;
@@ -42,7 +50,11 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
+import static fr.gouv.vitam.tools.resip.app.ResipGraphicApp.OK_DIALOG;
+import static fr.gouv.vitam.tools.resip.utils.ResipLogger.getGlobalLogger;
 import static fr.gouv.vitam.tools.sedalib.inout.exporter.DataObjectPackageToCSVMetadataExporter.*;
+import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.GLOBAL;
+import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.doProgressLogWithoutInterruption;
 import static java.awt.event.ItemEvent.DESELECTED;
 import static java.awt.event.ItemEvent.SELECTED;
 
@@ -93,6 +105,7 @@ public class PrefsDialog extends JDialog {
     private JTextArea metadataFilterTextArea;
     private JCheckBox metadataFilterCheckBox;
 
+    private JRadioButton seda2Version1RadioButton;
     private JTextField dupMaxTextField;
     private JRadioButton structuredInterfaceRadioButton;
     private JCheckBox debugModeCheckBox;
@@ -950,8 +963,8 @@ public class PrefsDialog extends JDialog {
         tabbedPane.addTab("Traitement/Interface", new ImageIcon(getClass().getResource("/icon/edit-find-replace.png")),
                 treatmentParametersPanel, null);
         GridBagLayout gbl_treatmentParametersPanel = new GridBagLayout();
-        gbl_treatmentParametersPanel.rowHeights = new int[]{0, 0, 0, 0, 0, 0,0};
-        gbl_treatmentParametersPanel.rowWeights = new double[]{0, 0, 0, 0, 0,0, 1.0};
+        gbl_treatmentParametersPanel.rowHeights = new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0};
+        gbl_treatmentParametersPanel.rowWeights = new double[]{0, 0, 0, 0, 0, 0, 0, 0, 1.0};
         treatmentParametersPanel.setLayout(gbl_treatmentParametersPanel);
 
         JLabel workDirLabel = new JLabel("Répertoire de travail");
@@ -1028,6 +1041,44 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
         treatmentParametersPanel.add(dupMaxTextField, gbc);
 
+        JLabel sedaVersionLabel = new JLabel("Version du Standard d'Echange utilisé (SEDA)");
+        sedaVersionLabel.setFont(MainWindow.BOLD_LABEL_FONT);
+        gbc = new GridBagConstraints();
+        gbc.gridwidth = 3;
+        gbc.insets = new Insets(5, 5, 5, 5);
+        gbc.weightx = 1.0;
+        gbc.anchor = GridBagConstraints.NORTHWEST;
+        gbc.fill = GridBagConstraints.HORIZONTAL;
+        gbc.gridx = 0;
+        gbc.gridy = 4;
+        treatmentParametersPanel.add(sedaVersionLabel, gbc);
+
+        seda2Version1RadioButton = new JRadioButton("SEDA 2.1");
+        gbc = new GridBagConstraints();
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.insets = new Insets(0, 0, 5, 5);
+        gbc.gridx = 1;
+        gbc.gridy = 5;
+        treatmentParametersPanel.add(seda2Version1RadioButton, gbc);
+
+        JRadioButton seda2Version2RadioButton = new JRadioButton("SEDA 2.2");
+        gbc = new GridBagConstraints();
+        gbc.anchor = GridBagConstraints.WEST;
+        gbc.insets = new Insets(0, 0, 5, 5);
+        gbc.gridx = 2;
+        gbc.gridy = 5;
+        treatmentParametersPanel.add(seda2Version2RadioButton, gbc);
+
+        ButtonGroup seda2VersionButtonGroup = new ButtonGroup();
+        seda2VersionButtonGroup.add(seda2Version1RadioButton);
+        seda2VersionButtonGroup.add(seda2Version2RadioButton);
+        seda2VersionButtonGroup.clearSelection();
+        if (tp.getSeda2Version() == 1)
+            seda2Version1RadioButton.setSelected(true);
+        else
+            seda2Version2RadioButton.setSelected(true);
+
+
         JLabel interfaceLabel = new JLabel("Interface");
         interfaceLabel.setFont(MainWindow.BOLD_LABEL_FONT);
         gbc = new GridBagConstraints();
@@ -1037,7 +1088,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.fill = GridBagConstraints.HORIZONTAL;
         gbc.gridx = 0;
-        gbc.gridy = 4;
+        gbc.gridy = 6;
         treatmentParametersPanel.add(interfaceLabel, gbc);
 
         JLabel interfaceTypeLabel = new JLabel("Interface par défaut:");
@@ -1045,7 +1096,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.EAST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 0;
-        gbc.gridy = 5;
+        gbc.gridy = 7;
         treatmentParametersPanel.add(interfaceTypeLabel, gbc);
 
         structuredInterfaceRadioButton = new JRadioButton("Structurée");
@@ -1053,7 +1104,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 1;
-        gbc.gridy = 5;
+        gbc.gridy = 7;
         treatmentParametersPanel.add(structuredInterfaceRadioButton, gbc);
 
         JRadioButton classicInterfaceRadioButton = new JRadioButton("XML-expert");
@@ -1061,7 +1112,7 @@ public class PrefsDialog extends JDialog {
         gbc.anchor = GridBagConstraints.WEST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 2;
-        gbc.gridy = 5;
+        gbc.gridy = 7;
         treatmentParametersPanel.add(classicInterfaceRadioButton, gbc);
 
         ButtonGroup interfaceTypeButtonGroup = new ButtonGroup();
@@ -1073,22 +1124,21 @@ public class PrefsDialog extends JDialog {
         else
             classicInterfaceRadioButton.setSelected(true);
 
-
         JLabel debugModeLabel = new JLabel("Mode débug actif:");
         gbc = new GridBagConstraints();
-        gbc.anchor = GridBagConstraints.EAST;
+        gbc.anchor = GridBagConstraints.NORTHEAST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 0;
-        gbc.gridy = 6;
+        gbc.gridy = 8;
         treatmentParametersPanel.add(debugModeLabel, gbc);
 
         debugModeCheckBox = new JCheckBox("");
         debugModeCheckBox.setSelected(ip.isDebugFlag());
         gbc = new GridBagConstraints();
-        gbc.anchor = GridBagConstraints.WEST;
+        gbc.anchor = GridBagConstraints.NORTHWEST;
         gbc.insets = new Insets(0, 0, 5, 5);
         gbc.gridx = 1;
-        gbc.gridy = 6;
+        gbc.gridy = 8;
         treatmentParametersPanel.add(debugModeCheckBox, gbc);
 
         // Buttons
@@ -1135,7 +1185,7 @@ public class PrefsDialog extends JDialog {
     private void buttonOk() {
         if (!extractFromDialog())
             return;
-        returnValue = ResipGraphicApp.OK_DIALOG;
+        returnValue = OK_DIALOG;
         setVisible(false);
     }
 
@@ -1164,7 +1214,7 @@ public class PrefsDialog extends JDialog {
                     "Erreur", UserInteractionDialog.ERROR_DIALOG,
                     null);
             ResipLogger.getGlobalLogger().log(ResipLogger.ERROR,
-                    "Resip.GraphicApp: Erreur fatale, impossible de sélectionner sur le disque",e);
+                    "Resip.GraphicApp: Erreur fatale, impossible de sélectionner sur le disque", e);
         }
     }
 
@@ -1239,6 +1289,55 @@ public class PrefsDialog extends JDialog {
             return false;
         }
         tp.setDupMax(tmp);
+
+        int toSeda2Version = (seda2Version1RadioButton.isSelected() ? 1 : 2);
+        if ((tp.getSeda2Version() != toSeda2Version) && (ResipGraphicApp.getTheApp().currentWork != null)) {
+            if (UserInteractionDialog.getUserAnswer(this.owner,
+                    "Attention, un SIP est ouvert et vous changez de version de SEDA2.x\n" +
+                            "Voulez-vous essayer de le convertir?",
+                    "Confirmation", UserInteractionDialog.WARNING_DIALOG,
+                    null) != OK_DIALOG)
+                return false;
+            else {
+                DataObjectPackage dop = ResipGraphicApp.getTheApp().currentWork.getDataObjectPackage();
+                InOutDialog inOutDialog = new InOutDialog(this.owner, "Conversion vers le schéma SEDA 2." + toSeda2Version);
+                ChangeSeda2VersionThread changeSeda2VersionThread = new ChangeSeda2VersionThread(toSeda2Version, dop, inOutDialog);
+                try {
+                    changeSeda2VersionThread.execute();
+                    inOutDialog.setVisible(true);
+                    while (!changeSeda2VersionThread.isDone()) Thread.sleep(100);
+                }
+                catch (Exception e) {
+                    UserInteractionDialog.getUserAnswer(this.owner,
+                            "Impossible de faire la conversion vers le schéma SEDA 2." +
+                                toSeda2Version +"\n->" + e.getMessage(),
+                            "Erreur", UserInteractionDialog.ERROR_DIALOG,
+                            null);
+                    getGlobalLogger().log(ResipLogger.ERROR, "resip.graphicapp: erreur fatale, impossible de faire l'import",e);
+                    return false;
+                }
+                if (changeSeda2VersionThread.convertedDop == null) {
+                    inOutDialog.setVisible(true);
+                    UserInteractionDialog.getUserAnswer(this.owner,
+                            "Impossible de faire la conversion vers le schéma SEDA 2." +
+                                    toSeda2Version +"\n" +
+                                    "Fermez cet objet avant de changer le schéma SEDA utilisé\n->"
+                                    + changeSeda2VersionThread.exitThrowable,
+                            "Erreur", UserInteractionDialog.ERROR_DIALOG,
+                            null);
+                    getGlobalLogger().log(ResipLogger.ERROR, "resip.graphicapp: erreur fatale, impossible de faire la " +
+                            "conversion vers le schéma SEDA 2." + toSeda2Version, changeSeda2VersionThread.exitThrowable);
+                    return false;
+                }
+                ResipGraphicApp.getTheApp().currentWork.setDataObjectPackage(changeSeda2VersionThread.convertedDop);
+                ResipGraphicApp.getTheWindow().load();
+            }
+        }
+        tp.setSeda2Version((seda2Version1RadioButton.isSelected() ? 1 : 2));
+        try {
+            Seda2Version.setSeda2Version(tp.getSeda2Version());
+        } catch (SEDALibException ignored) {
+        }
 
         ip.setStructuredMetadataEditionFlag(structuredInterfaceRadioButton.isSelected());
         ip.setDebugFlag(debugModeCheckBox.isSelected());

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/parameters/TreatmentParameters.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/parameters/TreatmentParameters.java
@@ -51,6 +51,11 @@ public class TreatmentParameters {
     int dupMax;
 
     /**
+     * The SEDA2 subversion.
+     */
+    int seda2Version;
+
+    /**
      * Instantiates a new creation context.
      */
     public TreatmentParameters() {
@@ -87,6 +92,12 @@ public class TreatmentParameters {
         catch (NumberFormatException e){
             dupMax=1000;
         }
+        try {
+            seda2Version=Integer.parseInt(prefs.getPrefProperties().getProperty("treatmentParameters.seda2Version","1"));
+        }
+        catch (NumberFormatException e){
+            seda2Version=1;
+        }
     }
 
     /**
@@ -100,6 +111,7 @@ public class TreatmentParameters {
             prefs.getPrefProperties().setProperty("treatmentParameters.categories."+canonizeCategoryName(e.getKey()),String.join("|",e.getValue()));
         }
         prefs.getPrefProperties().setProperty("treatmentParameters.dupMax", Integer.toString(dupMax));
+        prefs.getPrefProperties().setProperty("treatmentParameters.seda2Version", Integer.toString(seda2Version));
     }
 
     /**
@@ -149,6 +161,7 @@ public class TreatmentParameters {
         formatByCategoryMap.put("Non connu",Arrays.asList("UNKNOWN"));
         formatByCategoryMap.put("Autres...",Arrays.asList("Other"));
         dupMax=1000;
+        seda2Version=1;
     }
 
     // Getters and setters
@@ -188,4 +201,24 @@ public class TreatmentParameters {
     public void setDupMax(int dupMax) {
         this.dupMax = dupMax;
     }
+
+    /**
+     * Gets seda version.
+     *
+     * @return the seda2 version
+     */
+    public int getSeda2Version() {
+        return seda2Version;
+    }
+
+    /**
+     * Sets seda2 version.
+     *
+     * @param sedaVersion the seda2 version
+     */
+    public void setSeda2Version(int sedaVersion) {
+        this.seda2Version = sedaVersion;
+    }
+
+
 }

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/SEDAObjectEditorConstants.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/SEDAObjectEditorConstants.java
@@ -250,6 +250,11 @@ public class SEDAObjectEditorConstants {
         translateMap.put("RepositoryObjectPID", "ID-Objet-SAE");
         translateMap.put("ExternalReference", "ID-externe");
 
+        // LinkingAgentIdentifier subfields
+        translateMap.put("LinkingAgentIdentifierType", "Type d'indentifiant");
+        translateMap.put("LinkingAgentIdentifierValue", "Valeur d'identifiant");
+        translateMap.put("LinkingAgentRole", "Rôle");
+
         // Event subfields
         translateMap.put("EventIdentifier", "Identifiant");
         translateMap.put("EventTypeCode", "Code de type");
@@ -260,6 +265,7 @@ public class SEDAObjectEditorConstants {
         translateMap.put("OutcomeDetail", "Détail du résultat");
         translateMap.put("OutcomeDetailMessage", "Message de résultat");
         translateMap.put("EventDetailData", "Détail technique");
+        translateMap.put("LinkingAgentIdentifier", "Agent répertorié");
 
         // Signature all subfields
         translateMap.put("SigningTime", "Date de signature");

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/SEDAObjectEditorConstants.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/SEDAObjectEditorConstants.java
@@ -141,6 +141,8 @@ public class SEDAObjectEditorConstants {
         minimalTagList.add("FormatId");
         minimalTagList.add("Filename");
         minimalTagList.add("LastModified");
+        minimalTagList.add("LinkingAgentIdentifierType");
+        minimalTagList.add("LinkingAgentIdentifierValue");
 
         largeAreaTagList=new ArrayList<>();
         largeAreaTagList.add("Address");
@@ -158,6 +160,7 @@ public class SEDAObjectEditorConstants {
         translateMap.put("Coverage", "Couverture");
         translateMap.put("CreatedDate", "Date de création");
         translateMap.put("CustodialHistory", "Historique conservation");
+        translateMap.put("DateLitteral", "Date littérale");
         translateMap.put("Description", "Description");
         translateMap.put("DescriptionLanguage", "Langue de description");
         translateMap.put("DescriptionLevel", "Niveau de description");
@@ -323,6 +326,7 @@ public class SEDAObjectEditorConstants {
 
         //BinaryDataObject
         translateMap.put("BinaryDataObject", "Numérique");
+        translateMap.put("DataObjectProfile", "Profil d'objet");
         translateMap.put("DataObjectVersion", "Version");
         translateMap.put("MessageDigest", "Hachage");
         translateMap.put("Size", "Taille");

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/composite/BinaryDataObjectEditor.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/sedaobjecteditor/composite/BinaryDataObjectEditor.java
@@ -33,6 +33,7 @@ import fr.gouv.vitam.tools.resip.sedaobjecteditor.SEDAObjectEditor;
 import fr.gouv.vitam.tools.resip.sedaobjecteditor.components.structuredcomponents.SEDAObjectEditorCompositePanel;
 import fr.gouv.vitam.tools.resip.parameters.Prefs;
 import fr.gouv.vitam.tools.sedalib.core.BinaryDataObject;
+import fr.gouv.vitam.tools.sedalib.core.SEDA2Version;
 import fr.gouv.vitam.tools.sedalib.droid.DroidIdentifier;
 import fr.gouv.vitam.tools.sedalib.metadata.SEDAMetadata;
 import fr.gouv.vitam.tools.sedalib.metadata.data.FileInfo;
@@ -76,22 +77,27 @@ public class BinaryDataObjectEditor extends CompositeEditor {
     /**
      * Ordered SEDAObjectEditor collection
      */
-    static final int MESSAGE_DIGEST = 2;
-    static final int SIZE = 3;
-    static final int FORMAT_IDENTIFICATION = 5;
-    static final int FILE_INFO = 6;
+    static final int DATA_OBJECT_PROFILE = 0;
+    static final int DATA_OBJECT_VERSION = 1;
+    static final int URI = 2;
+    static final int MESSAGE_DIGEST = 3;
+    static final int SIZE = 4;
+    static final int COMPRESSED = 5;
+    static final int FORMAT_IDENTIFICATION = 6;
+    static final int FILE_INFO = 7;
+    static final int METADATA = 8;
     private SEDAObjectEditor[] objectEditorArray;
 
     /**
      * Instantiates a new BinaryDataObject editor.
      *
      * @param editedObject the BinaryDataObject editedObject
-     * @param father   the father
+     * @param father       the father
      */
     public BinaryDataObjectEditor(BinaryDataObject editedObject, SEDAObjectEditor father) {
         super(editedObject, father);
         this.editedOnDiskPath = editedObject.getOnDiskPath();
-        this.objectEditorArray = new SEDAObjectEditor[8];
+        this.objectEditorArray = new SEDAObjectEditor[9];
     }
 
     private BinaryDataObject getBinaryDataObjectMetadata() {
@@ -117,6 +123,9 @@ public class BinaryDataObjectEditor extends CompositeEditor {
         for (SEDAObjectEditor objectEditor : objectEditorList) {
             SEDAMetadata subMetadata = (SEDAMetadata) objectEditor.extractEditedObject();
             switch (subMetadata.getXmlElementName()) {
+                case "DataObjectProfile":
+                    tmpBdo.dataObjectProfile = (StringType) subMetadata;
+                    break;
                 case "DataObjectVersion":
                     tmpBdo.dataObjectVersion = (StringType) subMetadata;
                     break;
@@ -143,6 +152,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                     break;
             }
         }
+        getBinaryDataObjectMetadata().dataObjectProfile = tmpBdo.dataObjectProfile;
         getBinaryDataObjectMetadata().dataObjectVersion = tmpBdo.dataObjectVersion;
         getBinaryDataObjectMetadata().uri = tmpBdo.uri;
         getBinaryDataObjectMetadata().messageDigest = tmpBdo.messageDigest;
@@ -158,8 +168,11 @@ public class BinaryDataObjectEditor extends CompositeEditor {
 
     @Override
     public String getSummary() throws SEDALibException {
-        List<String> summaryList = new ArrayList<String>(objectEditorList.size());
+        List<String> summaryList = new ArrayList<>(objectEditorList.size());
         String tmp;
+
+        if (getBinaryDataObjectMetadata().dataObjectProfile != null)
+            summaryList.add(getBinaryDataObjectMetadata().dataObjectProfile.getValue());
 
         if (getBinaryDataObjectMetadata().dataObjectVersion != null)
             summaryList.add(getBinaryDataObjectMetadata().dataObjectVersion.getValue());
@@ -172,7 +185,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                 tmp = translateTag("Unknown");
         } else
             tmp = translateTag("Unknown");
-        tmp=tmp.trim();
+        tmp = tmp.trim();
         if (!tmp.isEmpty())
             summaryList.add(tmp);
 
@@ -182,7 +195,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                 tmp = translateTag("Unknown");
         } else
             tmp = translateTag("Unknown");
-        tmp=tmp.trim();
+        tmp = tmp.trim();
         if (!tmp.isEmpty())
             summaryList.add(tmp);
 
@@ -192,7 +205,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                 tmp = translateTag("Unknown");
         } else
             tmp = translateTag("Unknown");
-        tmp=tmp.trim();
+        tmp = tmp.trim();
         if (!tmp.isEmpty())
             summaryList.add(tmp);
 
@@ -202,7 +215,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                 tmp = translateTag("Unknown");
         } else
             tmp = translateTag("Unknown");
-        tmp=tmp.trim();
+        tmp = tmp.trim();
         if (!tmp.isEmpty())
             summaryList.add(tmp);
 
@@ -210,8 +223,8 @@ public class BinaryDataObjectEditor extends CompositeEditor {
     }
 
     private void updateObjectEditorList() throws SEDALibException {
-        List<SEDAObjectEditor> result = new ArrayList<SEDAObjectEditor>();
-        for (int i = 0; i < 8; i++)
+        List<SEDAObjectEditor> result = new ArrayList<>();
+        for (int i = 0; i < objectEditorArray.length; i++)
             if (objectEditorArray[i] != null)
                 result.add(objectEditorArray[i]);
         objectEditorList = result;
@@ -254,22 +267,24 @@ public class BinaryDataObjectEditor extends CompositeEditor {
         moreButtons.add(defineButton);
 
         this.sedaObjectEditorPanel = new SEDAObjectEditorCompositePanel(this, moreButtons, false);
+        if (getBinaryDataObjectMetadata().dataObjectProfile != null)
+            objectEditorArray[DATA_OBJECT_PROFILE]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().dataObjectProfile, this);
         if (getBinaryDataObjectMetadata().dataObjectVersion != null)
-            objectEditorArray[0] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().dataObjectVersion, this);
+            objectEditorArray[DATA_OBJECT_VERSION]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().dataObjectVersion, this);
         if (getBinaryDataObjectMetadata().uri != null)
-            objectEditorArray[1] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().uri, this);
+            objectEditorArray[URI]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().uri, this);
         if (getBinaryDataObjectMetadata().messageDigest != null)
-            objectEditorArray[2] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().messageDigest, this);
+            objectEditorArray[MESSAGE_DIGEST]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().messageDigest, this);
         if (getBinaryDataObjectMetadata().size != null)
-            objectEditorArray[3] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().size, this);
+            objectEditorArray[SIZE]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().size, this);
         if (getBinaryDataObjectMetadata().compressed != null)
-            objectEditorArray[4] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().compressed, this);
+            objectEditorArray[COMPRESSED]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().compressed, this);
         if (getBinaryDataObjectMetadata().formatIdentification != null)
-            objectEditorArray[5] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().formatIdentification, this);
+            objectEditorArray[FORMAT_IDENTIFICATION]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().formatIdentification, this);
         if (getBinaryDataObjectMetadata().fileInfo != null)
-            objectEditorArray[6] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().fileInfo, this);
+            objectEditorArray[FILE_INFO]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().fileInfo, this);
         if (getBinaryDataObjectMetadata().metadata != null)
-            objectEditorArray[7] = SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().metadata, this);
+            objectEditorArray[METADATA]= SEDAObjectEditor.createSEDAObjectEditor(getBinaryDataObjectMetadata().metadata, this);
         updateObjectEditorList();
     }
 
@@ -283,7 +298,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                         Files.setAttribute(editedOnDiskPath, "dos:readonly", true);
                 } catch (IOException e) {
                     UserInteractionDialog.getUserAnswer(ResipGraphicApp.getTheWindow(),
-                            "Impossible de passer le fichier à ouvrir ["+editedOnDiskPath.toString()+
+                            "Impossible de passer le fichier à ouvrir [" + editedOnDiskPath.toString() +
                                     "] en lecture seule \n->" + e.getMessage(),
                             "Erreur", UserInteractionDialog.ERROR_DIALOG,
                             null);
@@ -318,9 +333,9 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                                 "Voulez-vous extraire automatiquement les informations de ce fichier?",
                                 "Question", UserInteractionDialog.WARNING_DIALOG,
                                 null) == OK_DIALOG) {
-                    objectEditorArray[MESSAGE_DIGEST] = createSEDAObjectEditor(new DigestType("MessageDigest",
+                    objectEditorArray[MESSAGE_DIGEST] =createSEDAObjectEditor(new DigestType("MessageDigest",
                             getDigestSha512(editedOnDiskPath), "SHA-512"), this);
-                    objectEditorArray[SIZE] = createSEDAObjectEditor(new IntegerType("Size",
+                    objectEditorArray[SIZE] =createSEDAObjectEditor(new IntegerType("Size",
                             Files.size(editedOnDiskPath)), this);
 
                     boolean expanded = false;
@@ -334,7 +349,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                     else
                         formatIdentification = new FormatIdentification(translateTag("Unknown"), null,
                                 translateTag("Unknown"), null);
-                    objectEditorArray[FORMAT_IDENTIFICATION] = createSEDAObjectEditor(formatIdentification, this);
+                    objectEditorArray[FORMAT_IDENTIFICATION] =createSEDAObjectEditor(formatIdentification, this);
                     ((SEDAObjectEditorCompositePanel) objectEditorArray[FORMAT_IDENTIFICATION].getSEDAObjectEditorPanel()).setExpanded(expanded);
 
                     expanded = false;
@@ -343,7 +358,7 @@ public class BinaryDataObjectEditor extends CompositeEditor {
                     FileInfo fileInfo = new FileInfo();
                     fileInfo.addNewMetadata("Filename", editedOnDiskPath.getFileName().toString());
                     fileInfo.addNewMetadata("LastModified", Files.getLastModifiedTime(editedOnDiskPath).toString());
-                    objectEditorArray[FILE_INFO] = createSEDAObjectEditor(fileInfo, this);
+                    objectEditorArray[FILE_INFO] =createSEDAObjectEditor(fileInfo, this);
                     ((SEDAObjectEditorCompositePanel) objectEditorArray[FILE_INFO].getSEDAObjectEditorPanel()).setExpanded(expanded);
 
                     updateObjectEditorList();
@@ -359,14 +374,33 @@ public class BinaryDataObjectEditor extends CompositeEditor {
 
     @Override
     public List<Pair<String, String>> getExtensionList() throws SEDALibException {
-        List<Pair<String, String>> extensionList = new ArrayList<Pair<String, String>>(Arrays.asList(
-                Pair.of("DataObjectVersion", translateTag("DataObjectVersion")),
-                Pair.of("Uri", translateTag("Uri")),
-                Pair.of("MessageDigest", translateTag("MessageDigest")),
-                Pair.of("Size", translateTag("Size")),
-                Pair.of("FormatIdentification", translateTag("FormatIdentification")),
-                Pair.of("FileInfo", translateTag("FileInfo")),
-                Pair.of("Metadata", translateTag("Metadata"))));
+        List<Pair<String, String>> extensionList;
+
+        switch (SEDA2Version.getSeda2Version()) {
+            case 1:
+                extensionList = new ArrayList<Pair<String, String>>(Arrays.asList(
+                        Pair.of("DataObjectVersion", translateTag("DataObjectVersion")),
+                        Pair.of("Uri", translateTag("Uri")),
+                        Pair.of("MessageDigest", translateTag("MessageDigest")),
+                        Pair.of("Size", translateTag("Size")),
+                        Pair.of("FormatIdentification", translateTag("FormatIdentification")),
+                        Pair.of("FileInfo", translateTag("FileInfo")),
+                        Pair.of("Metadata", translateTag("Metadata"))));
+                break;
+            case 2:
+                extensionList = new ArrayList<Pair<String, String>>(Arrays.asList(
+                        Pair.of("DataObjectProfile", translateTag("DataObjectProfile")),
+                        Pair.of("DataObjectVersion", translateTag("DataObjectVersion")),
+                        Pair.of("Uri", translateTag("Uri")),
+                        Pair.of("MessageDigest", translateTag("MessageDigest")),
+                        Pair.of("Size", translateTag("Size")),
+                        Pair.of("FormatIdentification", translateTag("FormatIdentification")),
+                        Pair.of("FileInfo", translateTag("FileInfo")),
+                        Pair.of("Metadata", translateTag("Metadata"))));
+                break;
+            default:
+                throw new SEDALibException("Version SEDA [" + SEDA2Version.getSeda2VersionString() + "] inconnue", null);
+        }
 
         for (SEDAObjectEditor me : objectEditorList) {
             String name = me.getTag();
@@ -379,37 +413,41 @@ public class BinaryDataObjectEditor extends CompositeEditor {
     public void addChild(String metadataName) throws SEDALibException {
         SEDAMetadata sedaMetadata = null;
         switch (metadataName) {
+            case "DataObjectProfile":
+                sedaMetadata = createSEDAMetadataSample("StringType", "DataObjectProfile", true);
+                objectEditorArray[DATA_OBJECT_PROFILE] = createSEDAObjectEditor(sedaMetadata, this);
+                break;
             case "DataObjectVersion":
                 sedaMetadata = createSEDAMetadataSample("StringType", "DataObjectVersion", true);
-                objectEditorArray[0] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[DATA_OBJECT_VERSION] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
             case "Uri":
                 sedaMetadata = createSEDAMetadataSample("StringType", "Uri", true);
-                objectEditorArray[1] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[URI] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
             case "MessageDigest":
                 sedaMetadata = createSEDAMetadataSample("DigestType", "MessageDigest", true);
-                objectEditorArray[2] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[MESSAGE_DIGEST] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
             case "Size":
                 sedaMetadata = createSEDAMetadataSample("IntegerType", "Size", true);
-                objectEditorArray[3] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[SIZE] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
             case "Compressed":
                 sedaMetadata = createSEDAMetadataSample("StringType", "Compressed", true);
-                objectEditorArray[4] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[COMPRESSED] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
             case "FormatIdentification":
                 sedaMetadata = createSEDAMetadataSample("FormatIdentification", "FormatIdentification", true);
-                objectEditorArray[5] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[FORMAT_IDENTIFICATION] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
             case "FileInfo":
                 sedaMetadata = createSEDAMetadataSample("FileInfo", "FileInfo", true);
-                objectEditorArray[6] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[FILE_INFO] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
             case "Metadata":
                 sedaMetadata = createSEDAMetadataSample("Metadata", "Metadata", true);
-                objectEditorArray[7] = createSEDAObjectEditor(sedaMetadata, this);
+                objectEditorArray[METADATA] = createSEDAObjectEditor(sedaMetadata, this);
                 break;
         }
         if (sedaMetadata == null)
@@ -438,6 +476,8 @@ public class BinaryDataObjectEditor extends CompositeEditor {
      */
     static public BinaryDataObject createBinaryDataObjectSample(boolean minimal) throws SEDALibException {
         BinaryDataObject result = new BinaryDataObject();
+        if (SEDA2Version.getSeda2Version()>1)
+            result.dataObjectProfile = (StringType) createSEDAMetadataSample("StringType", "DataObjectProfile", minimal);
         result.dataObjectVersion = (StringType) createSEDAMetadataSample("StringType", "DataObjectVersion", minimal);
         result.messageDigest = (DigestType) createSEDAMetadataSample("DigestType", "MessageDigest", minimal);
         result.size = (IntegerType) createSEDAMetadataSample("IntegerType", "Size", minimal);

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/threads/ChangeSeda2VersionThread.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/threads/ChangeSeda2VersionThread.java
@@ -33,13 +33,11 @@ import fr.gouv.vitam.tools.resip.frame.InOutDialog;
 import fr.gouv.vitam.tools.resip.frame.PrefsDialog;
 import fr.gouv.vitam.tools.resip.utils.ResipException;
 import fr.gouv.vitam.tools.resip.utils.ResipLogger;
-import fr.gouv.vitam.tools.sedalib.core.ArchiveTransfer;
 import fr.gouv.vitam.tools.sedalib.core.DataObjectPackage;
-import fr.gouv.vitam.tools.sedalib.core.Seda2Version;
+import fr.gouv.vitam.tools.sedalib.core.SEDA2Version;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger;
 
 import javax.swing.*;
-import javax.xml.crypto.Data;
 
 import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.GLOBAL;
 import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.doProgressLogWithoutInterruption;
@@ -97,7 +95,7 @@ public class ChangeSeda2VersionThread extends SwingWorker<String, String> {
             if (work == null)
                 throw new ResipException("Pas de contenu à transformer");
 
-            convertedDop = Seda2Version.convertToSeda2Version(work.getDataObjectPackage(), toSeda2Version, spl);
+            convertedDop = SEDA2Version.convertToSeda2Version(work.getDataObjectPackage(), toSeda2Version, spl);
         } catch (Throwable e) {
             exitThrowable = e;
         }

--- a/resip/src/main/java/fr/gouv/vitam/tools/resip/threads/CheckEndDateThread.java
+++ b/resip/src/main/java/fr/gouv/vitam/tools/resip/threads/CheckEndDateThread.java
@@ -20,7 +20,7 @@ import java.util.Map;
 import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.GLOBAL;
 import static fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger.doProgressLogWithoutInterruption;
 
-public class CheckEndDateThread  extends SwingWorker<String, InOutDialog> {
+public class CheckEndDateThread  extends SwingWorker<String, String> {
     private final VerifyDateDialog verifyDateDialog;
     //run output
     private Throwable exitThrowable;

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/ArchiveTransfer.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/ArchiveTransfer.java
@@ -170,6 +170,7 @@ public class ArchiveTransfer {
         try {
             xmlWriter.writeEndElement();
             xmlWriter.writeEndDocument();
+            xmlWriter.flush();
         } catch (XMLStreamException e) {
             throw new SEDALibException("Erreur d'écriture XML de la cloture du manifest", e);
         }

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/ArchiveTransfer.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/ArchiveTransfer.java
@@ -105,10 +105,22 @@ public class ArchiveTransfer {
             xmlWriter.writeStartElement("ArchiveTransfer");
             xmlWriter.writeNamespace("xlink", "http://www.w3.org/1999/xlink");
             xmlWriter.writeNamespace("pr", "info:lc/xmlns/premis-v2");
-            xmlWriter.writeDefaultNamespace("fr:gouv:culture:archivesdefrance:seda:v2.1");
-            xmlWriter.writeNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
-            xmlWriter.writeAttribute("xsi", "http://www.w3.org/2001/XMLSchema-instance", "schemaLocation",
-                    "fr:gouv:culture:archivesdefrance:seda:v2.1 seda-2.1-main.xsd");
+            switch(SEDA2Version.getSeda2Version()){
+                case 1:
+                    xmlWriter.writeDefaultNamespace("fr:gouv:culture:archivesdefrance:seda:v2.1");
+                    xmlWriter.writeNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+                    xmlWriter.writeAttribute("xsi", "http://www.w3.org/2001/XMLSchema-instance", "schemaLocation",
+                            "fr:gouv:culture:archivesdefrance:seda:v2.1 seda-2.1-main.xsd");
+                    break;
+                case 2:
+                    xmlWriter.writeDefaultNamespace("fr:gouv:culture:archivesdefrance:seda:v2.2");
+                    xmlWriter.writeNamespace("xsi", "http://www.w3.org/2001/XMLSchema-instance");
+                    xmlWriter.writeAttribute("xsi", "http://www.w3.org/2001/XMLSchema-instance", "schemaLocation",
+                            "fr:gouv:culture:archivesdefrance:seda:v2.2 seda-2.2-main.xsd");
+                    break;
+                default:
+                    throw new SEDALibException("Version de SEDA sans schéma",null);
+            }
             xmlWriter.setXmlId(true);
         } catch (XMLStreamException e) {
             throw new SEDALibException("Erreur d'écriture XML du début du manifest", e);

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackage.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackage.java
@@ -1016,8 +1016,9 @@ public class DataObjectPackage {
             xmlWriter.writeEndElement();
             xmlWriter.writeRawXMLBlockIfNotEmpty(managementMetadataXmlData);
             xmlWriter.writeEndElement();
+            xmlWriter.flush();
         } catch (XMLStreamException | SEDALibException e) {
-            throw new SEDALibException("Erreur d'écriture XML des métadonnées des ArchiveUnits", e);
+            throw new SEDALibException("Erreur d'écriture XML des métadonnées dans le DataObjectPackage", e);
         }
         doProgressLog(sedaLibProgressLogger, SEDALibProgressLogger.OBJECTS_GROUP, "sedalib: " + getNextInOutCounter() +
                 " métadonnées ArchiveUnit exportées dans le DataObjectPackage", null);
@@ -1050,8 +1051,7 @@ public class DataObjectPackage {
      *
      * @param xmlReader             the SEDAXMLEventReader reading the SEDA manifest
      * @param dataObjectPackage     the DataObjectPackage to be completed
-     * @param rootDir               the directory where the BinaryDataObject files are
-     *                              exported
+     * @param rootDir               the directory of the BinaryDataObject files
      * @param sedaLibProgressLogger the progress logger or null if no progress log expected
      * @throws SEDALibException     if the XML can't be read or SEDA scheme is not
      *                              respected

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/PhysicalDataObject.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/PhysicalDataObject.java
@@ -58,6 +58,11 @@ public class PhysicalDataObject extends DataObjectPackageIdElement implements Da
     // SEDA elements
 
     /**
+     * The data object profile (only in Seda 2.2).
+     */
+    public StringType dataObjectProfile;
+
+    /**
      * The data object system id.
      */
     public StringType dataObjectSystemId;
@@ -130,6 +135,7 @@ public class PhysicalDataObject extends DataObjectPackageIdElement implements Da
      */
     public PhysicalDataObject(DataObjectPackage dataObjectPackage) {
         super(dataObjectPackage);
+        this.dataObjectProfile = null;
         this.dataObjectSystemId = null;
         this.dataObjectGroupSystemId = null;
         this.relationshipsXmlData = new ArrayList<>();
@@ -154,6 +160,7 @@ public class PhysicalDataObject extends DataObjectPackageIdElement implements Da
      * uniqID in the structure.
      * <p>
      * Fragment sample: <code>
+     * &lt;DataObjectProfile&gt;DataObject1&lt;DataObjectProfile&gt;
      * &lt;DataObjectVersion&gt;PhysicalMaster_1&lt;/DataObjectVersion&gt;
      * &lt;PhysicalId&gt;940 W&lt;/PhysicalId&gt;
      * &lt;PhysicalDimensions&gt;
@@ -191,6 +198,8 @@ public class PhysicalDataObject extends DataObjectPackageIdElement implements Da
             xmlWriter.writeStartElement("PhysicalDataObject");
             xmlWriter.writeAttribute("id", inDataPackageObjectId);
 
+            if ((SEDA2Version.getSeda2Version()>1) && (dataObjectProfile != null))
+                dataObjectProfile.toSedaXml(xmlWriter);
             if (dataObjectSystemId != null)
                 dataObjectSystemId.toSedaXml(xmlWriter);
             if (dataObjectGroupSystemId != null)
@@ -266,6 +275,10 @@ public class PhysicalDataObject extends DataObjectPackageIdElement implements Da
         String nextElementName;
         try {
             nextElementName = xmlReader.peekName();
+            if ((SEDA2Version.getSeda2Version()>1) && (nextElementName != null) && (nextElementName.equals("DataObjectProfile"))) {
+                dataObjectProfile = (StringType) SEDAMetadata.fromSedaXml(xmlReader, StringType.class);
+                nextElementName = xmlReader.peekName();
+            }
             if ((nextElementName != null) && (nextElementName.equals("DataObjectSystemId"))) {
                 dataObjectSystemId = (StringType) SEDAMetadata.fromSedaXml(xmlReader, StringType.class);
                 nextElementName = xmlReader.peekName();
@@ -393,6 +406,7 @@ public class PhysicalDataObject extends DataObjectPackageIdElement implements Da
 
         if ((pdo.dataObjectGroupId != null) || (pdo.dataObjectGroupReferenceId != null))
             throw new SEDALibException("La référence à un DataObjectGroup n'est pas modifiable par édition");
+        this.dataObjectProfile = pdo.dataObjectProfile;
         this.dataObjectSystemId = pdo.dataObjectSystemId;
         this.dataObjectGroupSystemId = pdo.dataObjectGroupSystemId;
         this.relationshipsXmlData = pdo.relationshipsXmlData;

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/SEDA2Version.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/SEDA2Version.java
@@ -5,6 +5,7 @@ import fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger;
 import fr.gouv.vitam.tools.sedalib.xml.IndentXMLTool;
 import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLEventReader;
 import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLStreamWriter;
+import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLValidator;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
@@ -22,7 +23,7 @@ import java.util.Map;
  * implemented to convert a DataObjectPackage to another Seda2 version.
  * This is mostly done to be used in interactive program like Resip.</P>
  */
-public final class Seda2Version {
+public final class SEDA2Version {
     /**
      * For Seda2.1 SEDA2_1=1
      */
@@ -57,10 +58,10 @@ public final class Seda2Version {
      * @return the Seda2 version string
      */
     public static String getSeda2VersionString() {
-        return "Seda2." + globalSeda2Version;
+        return "SEDA 2." + globalSeda2Version;
     }
 
-    private Seda2Version() {
+    private SEDA2Version() {
         throw new IllegalStateException("Utility class");
     }
 
@@ -87,10 +88,12 @@ public final class Seda2Version {
      * @throws SEDALibException if this is not a supported version
      */
     public static void setSeda2Version(int newSeda2Version) throws SEDALibException {
-        if (isSupportedSeda2Version(newSeda2Version))
+        if (isSupportedSeda2Version(newSeda2Version)) {
             globalSeda2Version = newSeda2Version;
+            SEDAXMLValidator.resetSEDASchema();
+        }
         else
-            throw new SEDALibException("Unknown Seda2." + newSeda2Version + " version");
+            throw new SEDALibException("Unknown Seda 2." + newSeda2Version + " version");
     }
 
     /**

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
@@ -18,7 +18,8 @@ import java.util.Map;
  * <ul><li>only the ontology and a the xsd declaration are different, not the messages structure</li>
  * <li>the Seda2 version has not to be changed when previous version objects exist</li></ul>
  * The global Seda2 version is used in all SEDAMetadata class to adapt to ontology used.
- * <P>Warning: there is a very special function ({@link #convertToSeda2Version(DataObjectPackage, int, SedaLibProgressLogger) convertToSeda2Version}) implemented to convert a DataObjectPackage to another Seda2 version.
+ * <P>Warning: there is a very special method ({@link #convertToSeda2Version(DataObjectPackage, int, SEDALibProgressLogger)})
+ * implemented to convert a DataObjectPackage to another Seda2 version.
  * This is mostly done to be used in interactive program like Resip.</P>
  */
 public final class Seda2Version {

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
@@ -26,21 +26,21 @@ public final class Seda2Version {
     /**
      * For Seda2.1 SEDA2_1=1
      */
-    public final static int SEDA2_1 = 1;
+    public static final int SEDA2_1 = 1;
     /**
      * For Seda2.2 SEDA2_2=2
      */
-    public final static int SEDA2_2 = 2;
+    public static final int SEDA2_2 = 2;
     /**
      * Max Seda2.x supported version MAX_SUPPORTED_VERSION=2
      */
-    public final static int MAX_SUPPORTED_VERSION = 2;
+    public static final int MAX_SUPPORTED_VERSION = 2;
 
     /**
      * SEDA2 convention used for all lib processing
      * Warning: usage for different SEDA2 versions is not possible in parallel process!
      */
-    private static int seda2Version = SEDA2_1;
+    private static int globalSeda2Version = SEDA2_1;
 
     /**
      * Gets Seda2 version.
@@ -48,7 +48,7 @@ public final class Seda2Version {
      * @return the Seda2 version
      */
     public static int getSeda2Version() {
-        return seda2Version;
+        return globalSeda2Version;
     }
 
     /**
@@ -57,7 +57,11 @@ public final class Seda2Version {
      * @return the Seda2 version string
      */
     public static String getSeda2VersionString() {
-        return "Seda2." + seda2Version;
+        return "Seda2." + globalSeda2Version;
+    }
+
+    private Seda2Version() {
+        throw new IllegalStateException("Utility class");
     }
 
     /**
@@ -67,7 +71,7 @@ public final class Seda2Version {
      * @return the boolean
      */
     public static boolean isSupportedSeda2Version(int newSeda2Version) {
-        switch (seda2Version) {
+        switch (newSeda2Version) {
             case SEDA2_1:
             case SEDA2_2:
                 return true;
@@ -84,7 +88,7 @@ public final class Seda2Version {
      */
     public static void setSeda2Version(int newSeda2Version) throws SEDALibException {
         if (isSupportedSeda2Version(newSeda2Version))
-            seda2Version = newSeda2Version;
+            globalSeda2Version = newSeda2Version;
         else
             throw new SEDALibException("Unknown Seda2." + newSeda2Version + " version");
     }
@@ -93,10 +97,12 @@ public final class Seda2Version {
      * Convert à DataObjectPackage to Seda2 version using XML as pivot format.
      * <P>Warning: this very special function is mostly done to be used in interactive program like Resip.</P>
      *
-     * @param dataObjectPackage the DataObjectPackage
-     * @param toSeda2Version    the destination Seda2 version
+     * @param dataObjectPackage     the DataObjectPackage
+     * @param toSeda2Version        the destination Seda2 version
+     * @param sedaLibProgressLogger the seda lib progress logger
      * @return the converted DataObjectPackage
-     * @throws SEDALibException if not supported version or if conversion through XML is not possible
+     * @throws SEDALibException     if not supported version or if conversion through XML is not possible
+     * @throws InterruptedException the interrupted exception
      */
     public static DataObjectPackage convertToSeda2Version(DataObjectPackage dataObjectPackage, int toSeda2Version, SEDALibProgressLogger sedaLibProgressLogger)
             throws SEDALibException, InterruptedException {
@@ -115,7 +121,7 @@ public final class Seda2Version {
              SEDAXMLStreamWriter oxsw = new SEDAXMLStreamWriter(baos, IndentXMLTool.STANDARD_INDENT)) {
             dataObjectPackage.toSedaXml(oxsw, true, sedaLibProgressLogger);
             xmlForm = baos.toString("UTF-8");
-        } catch (XMLStreamException | IOException | InterruptedException e) {
+        } catch (XMLStreamException | IOException e) {
             throw new SEDALibException("Echec d'écriture XML du DataObjectPackage dans la version seda2." + originSeda2Version, e);
         }
         setSeda2Version(toSeda2Version);
@@ -125,7 +131,7 @@ public final class Seda2Version {
              SEDAXMLEventReader ixer = new SEDAXMLEventReader(bais, true)) {
             ixer.xmlReader.nextEvent(); // drop the StartDocument event
             result = DataObjectPackage.fromSedaXml(ixer, "unknown", sedaLibProgressLogger);
-        } catch (XMLStreamException | IOException | InterruptedException e) {
+        } catch (XMLStreamException | IOException e) {
             setSeda2Version(originSeda2Version);
             throw new SEDALibException("Echec de conversion à travers XML du DataObjectPackage dans la version seda2." + toSeda2Version, e);
         }

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/core/Seda2Version.java
@@ -1,0 +1,137 @@
+package fr.gouv.vitam.tools.sedalib.core;
+
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibProgressLogger;
+import fr.gouv.vitam.tools.sedalib.xml.IndentXMLTool;
+import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLEventReader;
+import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLStreamWriter;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * The Seda2 version management class, make it possible to use different Seda2 version if:
+ * <ul><li>only the ontology and a the xsd declaration are different, not the messages structure</li>
+ * <li>the Seda2 version has not to be changed when previous version objects exist</li></ul>
+ * The global Seda2 version is used in all SEDAMetadata class to adapt to ontology used.
+ * <P>Warning: there is a very special function ({@link #convertToSeda2Version(DataObjectPackage, int, SedaLibProgressLogger) convertToSeda2Version}) implemented to convert a DataObjectPackage to another Seda2 version.
+ * This is mostly done to be used in interactive program like Resip.</P>
+ */
+public final class Seda2Version {
+    /**
+     * For Seda2.1 SEDA2_1=1
+     */
+    public final static int SEDA2_1 = 1;
+    /**
+     * For Seda2.2 SEDA2_2=2
+     */
+    public final static int SEDA2_2 = 2;
+    /**
+     * Max Seda2.x supported version MAX_SUPPORTED_VERSION=2
+     */
+    public final static int MAX_SUPPORTED_VERSION = 2;
+
+    /**
+     * SEDA2 convention used for all lib processing
+     * Warning: usage for different SEDA2 versions is not possible in parallel process!
+     */
+    private static int seda2Version = SEDA2_1;
+
+    /**
+     * Gets Seda2 version.
+     *
+     * @return the Seda2 version
+     */
+    public static int getSeda2Version() {
+        return seda2Version;
+    }
+
+    /**
+     * Gets Seda2 version string.
+     *
+     * @return the Seda2 version string
+     */
+    public static String getSeda2VersionString() {
+        return "Seda2." + seda2Version;
+    }
+
+    /**
+     * Is supported Seda2 version boolean.
+     *
+     * @param newSeda2Version the new seda 2 version
+     * @return the boolean
+     */
+    public static boolean isSupportedSeda2Version(int newSeda2Version) {
+        switch (seda2Version) {
+            case SEDA2_1:
+            case SEDA2_2:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    /**
+     * Sets Seda2 version.
+     *
+     * @param newSeda2Version the new Seda2 version
+     * @throws SEDALibException if this is not a supported version
+     */
+    public static void setSeda2Version(int newSeda2Version) throws SEDALibException {
+        if (isSupportedSeda2Version(newSeda2Version))
+            seda2Version = newSeda2Version;
+        else
+            throw new SEDALibException("Unknown Seda2." + newSeda2Version + " version");
+    }
+
+    /**
+     * Convert à DataObjectPackage to Seda2 version using XML as pivot format.
+     * <P>Warning: this very special function is mostly done to be used in interactive program like Resip.</P>
+     *
+     * @param dataObjectPackage the DataObjectPackage
+     * @param toSeda2Version    the destination Seda2 version
+     * @return the converted DataObjectPackage
+     * @throws SEDALibException if not supported version or if conversion through XML is not possible
+     */
+    public static DataObjectPackage convertToSeda2Version(DataObjectPackage dataObjectPackage, int toSeda2Version, SEDALibProgressLogger sedaLibProgressLogger)
+            throws SEDALibException, InterruptedException {
+        String xmlForm;
+        DataObjectPackage result;
+        int originSeda2Version = getSeda2Version();
+
+        if (!isSupportedSeda2Version(toSeda2Version))
+            throw new SEDALibException("Unknown Seda2." + toSeda2Version + " version");
+
+        SEDALibProgressLogger.doProgressLog(sedaLibProgressLogger,SEDALibProgressLogger.GLOBAL,
+                "Passage de la version Seda2."+originSeda2Version+" à la version Seda2."+toSeda2Version,null);
+        SEDALibProgressLogger.doProgressLog(sedaLibProgressLogger,SEDALibProgressLogger.STEP,
+                "-> Ecriture XML en version Seda2."+originSeda2Version,null);
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream();
+             SEDAXMLStreamWriter oxsw = new SEDAXMLStreamWriter(baos, IndentXMLTool.STANDARD_INDENT)) {
+            dataObjectPackage.toSedaXml(oxsw, true, sedaLibProgressLogger);
+            xmlForm = baos.toString("UTF-8");
+        } catch (XMLStreamException | IOException | InterruptedException e) {
+            throw new SEDALibException("Echec d'écriture XML du DataObjectPackage dans la version seda2." + originSeda2Version, e);
+        }
+        setSeda2Version(toSeda2Version);
+        SEDALibProgressLogger.doProgressLog(sedaLibProgressLogger,SEDALibProgressLogger.STEP,
+                "-> Prise en compte à partir de l'XML généré, vers la version Seda2."+toSeda2Version,null);
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(xmlForm.getBytes(StandardCharsets.UTF_8));
+             SEDAXMLEventReader ixer = new SEDAXMLEventReader(bais, true)) {
+            ixer.xmlReader.nextEvent(); // drop the StartDocument event
+            result = DataObjectPackage.fromSedaXml(ixer, "unknown", sedaLibProgressLogger);
+        } catch (XMLStreamException | IOException | InterruptedException e) {
+            setSeda2Version(originSeda2Version);
+            throw new SEDALibException("Echec de conversion à travers XML du DataObjectPackage dans la version seda2." + toSeda2Version, e);
+        }
+        for (Map.Entry<String, BinaryDataObject> identifiedDataObject : dataObjectPackage.getBdoInDataObjectPackageIdMap().entrySet())
+            result.getBdoInDataObjectPackageIdMap().get(identifiedDataObject.getKey()).setOnDiskPath(identifiedDataObject.getValue().getOnDiskPath());
+        setSeda2Version(originSeda2Version);
+
+        return result;
+    }
+}

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/exporter/DataObjectPackageToCSVMetadataExporter.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/inout/exporter/DataObjectPackageToCSVMetadataExporter.java
@@ -261,7 +261,7 @@ public class DataObjectPackageToCSVMetadataExporter {
 
     // extract and sort headernames by there defined order in composed types
     private List<String> getSortedHeaderNames(List<String> sortedHeaderNames, Set<String> headerNames,
-                                              String prefixHeaderName, String xmlElementName, Class<?> metadataClass) {
+                                              String prefixHeaderName, String xmlElementName, Class<?> metadataClass) throws SEDALibException {
         String currentName = prefixHeaderName + (prefixHeaderName.isEmpty() ? "" : ".") + xmlElementName;
         String infix;
         int maxRank = getMaxRank(headerNames, currentName);

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/content/Content.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/content/Content.java
@@ -53,7 +53,7 @@ public class Content extends ComplexListType {
     /**
      * Init metadata map.
      */
-    @ComplexListMetadataMap(isExpandable = true)
+    @ComplexListMetadataMap(isExpandable = true, seda2Version = 1)
     public static final Map<String, ComplexListMetadataKind> metadataMap;
 
     static {
@@ -108,6 +108,65 @@ public class Content extends ComplexListType {
         // Vitam extensions
         metadataMap.put("OriginatingSystemIdReplyTo", new ComplexListMetadataKind(StringType.class, false));
         metadataMap.put("TextContent", new ComplexListMetadataKind(StringType.class, true));
+    }
+
+    @ComplexListMetadataMap(isExpandable = true, seda2Version = 2)
+    public static final Map<String, ComplexListMetadataKind> metadataMap_v2;
+
+    static {
+        metadataMap_v2 = new LinkedHashMap<>();
+        metadataMap_v2.put("DescriptionLevel", new ComplexListMetadataKind(DescriptionLevel.class, false));
+        metadataMap_v2.put("Title", new ComplexListMetadataKind(TextType.class, true));
+        metadataMap_v2.put("FilePlanPosition", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("SystemId", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("OriginatingSystemId", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("ArchivalAgencyArchiveUnitIdentifier",
+                new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("OriginatingAgencyArchiveUnitIdentifier",
+                new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("TransferringAgencyArchiveUnitIdentifier",
+                new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("Description", new ComplexListMetadataKind(TextType.class, true));
+        metadataMap_v2.put("CustodialHistory",
+                new ComplexListMetadataKind(CustodialHistory.class, false));
+        metadataMap_v2.put("Type", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("DocumentType", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("Language", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("DescriptionLanguage", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("Status", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("Version", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("Tag", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("Keyword", new ComplexListMetadataKind(Keyword.class, true));
+        metadataMap_v2.put("Coverage", new ComplexListMetadataKind(Coverage.class, false));
+        metadataMap_v2.put("OriginatingAgency",
+                new ComplexListMetadataKind(AgencyType.class, false));
+        metadataMap_v2.put("SubmissionAgency",
+                new ComplexListMetadataKind(AgencyType.class, false));
+        // specific in Seda 2.2
+        metadataMap_v2.put("Agent", new ComplexListMetadataKind(AgentType.class, true));
+        metadataMap_v2.put("AuthorizedAgent", new ComplexListMetadataKind(AgentType.class, true));
+        metadataMap_v2.put("Writer", new ComplexListMetadataKind(AgentType.class, true));
+        metadataMap_v2.put("Addressee", new ComplexListMetadataKind(AgentType.class, true));
+        metadataMap_v2.put("Recipient", new ComplexListMetadataKind(AgentType.class, true));
+        metadataMap_v2.put("Transmitter", new ComplexListMetadataKind(AgentType.class, true));
+        metadataMap_v2.put("Sender", new ComplexListMetadataKind(AgentType.class, true));
+        metadataMap_v2.put("Source", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("RelatedObjectReference", new ComplexListMetadataKind(RelatedObjectReference.class, false));
+        metadataMap_v2.put("CreatedDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("TransactedDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("AcquiredDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("SentDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("ReceivedDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("RegisteredDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("StartDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("EndDate", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("DateLitteral", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("Event", new ComplexListMetadataKind(Event.class, true));
+        metadataMap_v2.put("Signature", new ComplexListMetadataKind(Signature.class, true));
+        metadataMap_v2.put("Gps", new ComplexListMetadataKind(Gps.class, false));
+        // specific in Seda 2.2 (was in Vitam before)
+        metadataMap_v2.put("OriginatingSystemIdReplyTo", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("TextContent", new ComplexListMetadataKind(StringType.class, true));
     }
 
     /**

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/content/Event.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/content/Event.java
@@ -51,22 +51,43 @@ public class Event extends ComplexListType {
      * Init metadata map.
      */
     @ComplexListMetadataMap(isExpandable = true)
-    public static final Map<String, ComplexListMetadataKind> metadataMap;
+    public static final Map<String, ComplexListMetadataKind> metadataMap_default;
 
     static {
-        metadataMap = new LinkedHashMap<>();
-        metadataMap.put("EventIdentifier",
+        metadataMap_default = new LinkedHashMap<>();
+        metadataMap_default.put("EventIdentifier",
                 new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventTypeCode", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventType", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventDateTime", new ComplexListMetadataKind(DateTimeType.class, false));
-        metadataMap.put("EventDetail", new ComplexListMetadataKind(StringType.class, true));
-        metadataMap.put("Outcome", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("OutcomeDetail", new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("OutcomeDetailMessage",
+        metadataMap_default.put("EventTypeCode", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("EventType", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("EventDateTime", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_default.put("EventDetail", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_default.put("Outcome", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("OutcomeDetail", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_default.put("OutcomeDetailMessage",
                 new ComplexListMetadataKind(StringType.class, false));
-        metadataMap.put("EventDetailData",
+        metadataMap_default.put("EventDetailData",
                 new ComplexListMetadataKind(StringType.class, false));
+    }
+
+    @ComplexListMetadataMap(isExpandable = true, seda2Version = 2)
+    public static final Map<String, ComplexListMetadataKind> metadataMap_v2;
+
+    static {
+        metadataMap_v2 = new LinkedHashMap<>();
+        metadataMap_v2.put("EventIdentifier",
+                new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventTypeCode", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventType", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventDateTime", new ComplexListMetadataKind(DateTimeType.class, false));
+        metadataMap_v2.put("EventDetail", new ComplexListMetadataKind(StringType.class, true));
+        metadataMap_v2.put("Outcome", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("OutcomeDetail", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("OutcomeDetailMessage",
+                new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("EventDetailData",
+                new ComplexListMetadataKind(StringType.class, false));
+        metadataMap_v2.put("LinkingAgentIdentifier",
+                new ComplexListMetadataKind(LinkingAgentIdentifierType.class, true));
     }
 
     /**

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListMetadataMap.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListMetadataMap.java
@@ -5,5 +5,8 @@ import java.lang.annotation.RetentionPolicy;
 
 @Retention(RetentionPolicy.RUNTIME)
 public @interface ComplexListMetadataMap {
+    public static int NON_SPECIFIC_SEDA2_VERSION=-1;
+
     boolean isExpandable() default false;
+    int seda2Version() default NON_SPECIFIC_SEDA2_VERSION;
 }

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListType.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListType.java
@@ -28,6 +28,7 @@
 package fr.gouv.vitam.tools.sedalib.metadata.namedtype;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fr.gouv.vitam.tools.sedalib.core.Seda2Version;
 import fr.gouv.vitam.tools.sedalib.metadata.SEDAMetadata;
 import fr.gouv.vitam.tools.sedalib.metadata.content.Gps;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
@@ -46,10 +47,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
+import java.util.*;
 
 /**
  * The Class ComplexListType.
@@ -59,19 +57,32 @@ import java.util.List;
 public abstract class ComplexListType extends NamedTypeMetadata {
 
     /**
-     * The Sub type metadata ordered list map.
+     * The analyzed Sub type metadata set.
      */
-    protected static HashMap<Class<?>, List<String>> subTypeMetadataOrderedListMap = new HashMap<>();
+    protected static HashSet<Class<?>> analyzedSubTypeMetadataSet = new HashSet<>();
     /**
-     * The Sub type metadata map map.
+     * The Sub type metadata ordered list map by versions.
      */
-    protected static HashMap<Class<?>, LinkedHashMap<String, ComplexListMetadataKind>> subTypeMetadataMapMap =
-            new HashMap<>();
+    protected static HashMap<Class<?>, List<String>>[] subTypeMetadataOrderedListMap = new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
     /**
-     * The Sub type expandable map.
+     * The Sub type metadata map map by versions.
      */
-    protected static HashMap<Class<?>, Boolean> subTypeNotExpandableMap =
-            new HashMap<>();
+    protected static HashMap<Class<?>, LinkedHashMap<String, ComplexListMetadataKind>>[] subTypeMetadataMapMap =
+            new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
+    /**
+     * The Sub type expandable map by versions.
+     */
+    protected static HashMap<Class<?>, Boolean>[] subTypeNotExpandableMap =
+            new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
+
+    // init empty maps for all versions (index=version+1) and non specific one (index=0)
+    static {
+        for (int i=0;i<Seda2Version.MAX_SUPPORTED_VERSION+2;i++){
+            subTypeMetadataOrderedListMap[i]=new HashMap<>();
+            subTypeMetadataMapMap[i]=new HashMap<>();
+            subTypeNotExpandableMap[i]=new HashMap<>();
+        }
+    }
 
     /**
      * The metadata list.
@@ -377,7 +388,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      * Add metadata from fragments in XML expected form for the SEDA Manifest.
      *
      * @param xmlData the xml data
-     * @throws SEDALibException if the XML can't be read or the SEDA scheme is not                          respected
+     * @throws SEDALibException if the XML can't be read or the SEDA scheme is not respected
      */
     public void addSedaXmlFragments(String xmlData) throws SEDALibException {
         Class<?> metadataClass;
@@ -409,25 +420,36 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     private static void getNewComplexListSubType(Class<?> subClass) throws SEDALibException {
         List<Field> fields = FieldUtils.getFieldsListWithAnnotation(subClass, ComplexListMetadataMap.class);
         if (fields.isEmpty())
-            throw new SEDALibException("Le type " + subClass + " n'a pas de variable annotée @ComplexListMetadataMap accessible");
-        else if (fields.size() > 1)
-            throw new SEDALibException("Le type " + subClass + " a plusieurs variables annotées @ComplexListMetadataMap accessibles (classe ou parents)");
+            throw new SEDALibException("Le type " + subClass +
+                    " n'a pas de variable annotée @ComplexListMetadataMap accessible");
+        else if (fields.size() > Seda2Version.MAX_SUPPORTED_VERSION)
+            throw new SEDALibException("Le type " + subClass +
+                    " a un trop grand nombre de variables annotées @ComplexListMetadataMap accessibles");
 
         Object object;
+        int seda2Version;
+        boolean isExpandable;
         LinkedHashMap<String, ComplexListMetadataKind> metadataMap;
-        try {
-            object = fields.get(0).get(null);
-        } catch (IllegalAccessException e) {
-            throw new SEDALibException("La variable " + fields.get(0) + " annotée @ComplexListMetadataMap du type " + subClass + " ne peut être accédée", e);
+        for (int i = 0; i < fields.size();i++) {
+            try {
+                object = fields.get(i).get(null);
+                seda2Version= fields.get(i).getAnnotation(ComplexListMetadataMap.class).seda2Version();
+                isExpandable= fields.get(i).getAnnotation(ComplexListMetadataMap.class).isExpandable();
+            } catch (IllegalAccessException e) {
+                throw new SEDALibException("La variable " + fields.get(i) + " annotée @ComplexListMetadataMap du type " +
+                        subClass + " pour la version "+(i==-1?"par défaut":i)+" ne peut être accédée", e);
+            }
+            try {
+                metadataMap = (LinkedHashMap<String, ComplexListMetadataKind>) object;
+            } catch (ClassCastException e) {
+                throw new SEDALibException("La variable " + fields.get(i) + " annotée @ComplexListMetadataMap du type " +
+                        subClass + " n'est pas de type LinkedHashMap<String,ComplexListMetadataKind>", e);
+            }
+            subTypeMetadataMapMap[seda2Version+1].put(subClass, metadataMap);
+            subTypeMetadataOrderedListMap[seda2Version+1].put(subClass, new ArrayList<>(metadataMap.keySet()));
+            subTypeNotExpandableMap[seda2Version+1].put(subClass, !isExpandable);
         }
-        try {
-            metadataMap = (LinkedHashMap<String, ComplexListMetadataKind>) object;
-        } catch (ClassCastException e) {
-            throw new SEDALibException("La variable " + fields.get(0) + " annotée @ComplexListMetadataMap du type " + subClass + " n'est pas de type LinkedHashMap<String,ComplexListMetadataKind>", e);
-        }
-        subTypeMetadataMapMap.put(subClass, metadataMap);
-        subTypeMetadataOrderedListMap.put(subClass, new ArrayList<>(metadataMap.keySet()));
-        subTypeNotExpandableMap.put(subClass, !fields.get(0).getAnnotation(ComplexListMetadataMap.class).isExpandable());
+        analyzedSubTypeMetadataSet.add(subClass);
     }
 
     /**
@@ -438,11 +460,11 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      */
     @JsonIgnore
     public List<String> getMetadataOrderedList() throws SEDALibException {
-        List<String> metadataOrderedList = subTypeMetadataOrderedListMap.get(this.getClass());
-        if (metadataOrderedList == null) {
+        if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-            metadataOrderedList = subTypeMetadataOrderedListMap.get(this.getClass());
-        }
+        List<String> metadataOrderedList = subTypeMetadataOrderedListMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        if (metadataOrderedList == null)
+            metadataOrderedList = subTypeMetadataOrderedListMap[0].get(this.getClass());
         return metadataOrderedList;
     }
 
@@ -455,11 +477,11 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      */
     @JsonIgnore
     public HashMap<String, ComplexListMetadataKind> getMetadataMap() throws SEDALibException {
-        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap.get(this.getClass());
-        if (metadataMap == null) {
+        if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-            metadataMap = subTypeMetadataMapMap.get(this.getClass());
-        }
+        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        if (metadataMap == null)
+            metadataMap = subTypeMetadataMapMap[0].get(this.getClass());
         return metadataMap;
     }
 
@@ -469,9 +491,14 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      *
      * @param complexListTypeMetadataClass the complex list type metadata class
      * @return the metadata map
+     * @throws SEDALibException if the @ComplexListMetadataMap annotated static variable doesn't exist or is badly formed
      */
-    public static HashMap<String, ComplexListMetadataKind> getMetadataMap(Class<?> complexListTypeMetadataClass) {
-        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap.get(complexListTypeMetadataClass);
+    public static HashMap<String, ComplexListMetadataKind> getMetadataMap(Class<?> complexListTypeMetadataClass) throws SEDALibException {
+        if (!analyzedSubTypeMetadataSet.contains(complexListTypeMetadataClass))
+            getNewComplexListSubType(complexListTypeMetadataClass);
+        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[Seda2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
+        if (metadataMap == null)
+            metadataMap = subTypeMetadataMapMap[0].get(complexListTypeMetadataClass);
         return metadataMap;
     }
 
@@ -483,12 +510,12 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      */
     @JsonIgnore
     public boolean isNotExpendable() throws SEDALibException {
-        Boolean isNotExpandable = subTypeNotExpandableMap.get(this.getClass());
-        if (isNotExpandable == null) {
+        if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-            isNotExpandable = subTypeNotExpandableMap.get(this.getClass());
-        }
-        return isNotExpandable;
+        Boolean isNotExpandable = subTypeNotExpandableMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        if (isNotExpandable == null)
+            isNotExpandable = subTypeNotExpandableMap[0].get(this.getClass());
+         return isNotExpandable;
     }
 
     /**
@@ -496,9 +523,15 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      *
      * @param complexListTypeMetadataClass the complex list type metadata class
      * @return true, if is not expendable
+     * @throws SEDALibException if the @ComplexListMetadataMap annotated static variable doesn't exist or is badly formed
      */
-    public static Boolean isNotExpendable(Class<?> complexListTypeMetadataClass) {
-        return subTypeNotExpandableMap.get(complexListTypeMetadataClass);
+    public static Boolean isNotExpendable(Class<?> complexListTypeMetadataClass) throws SEDALibException {
+        if (!analyzedSubTypeMetadataSet.contains(complexListTypeMetadataClass))
+            getNewComplexListSubType(complexListTypeMetadataClass);
+        Boolean isNotExpandable = subTypeNotExpandableMap[Seda2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
+        if (isNotExpandable == null)
+            isNotExpandable = subTypeNotExpandableMap[0].get(complexListTypeMetadataClass);
+        return isNotExpandable;
     }
 
     /**
@@ -534,9 +567,10 @@ public abstract class ComplexListType extends NamedTypeMetadata {
      *
      * @param metadataName the metadata name
      * @return the boolean
+     * @throws SEDALibException if the @ComplexListMetadataMap annotated static variable doesn't exist or is badly formed
      */
-    public boolean isAMultiValuedMetadata(String metadataName) {
-        ComplexListMetadataKind clmk = subTypeMetadataMapMap.get(this.getClass()).get(metadataName);
+    public boolean isAMultiValuedMetadata(String metadataName) throws SEDALibException {
+        ComplexListMetadataKind clmk = getMetadataMap().get(metadataName);
         if (clmk == null)
             return true;
         return clmk.isMany();

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListType.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/ComplexListType.java
@@ -28,7 +28,7 @@
 package fr.gouv.vitam.tools.sedalib.metadata.namedtype;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import fr.gouv.vitam.tools.sedalib.core.Seda2Version;
+import fr.gouv.vitam.tools.sedalib.core.SEDA2Version;
 import fr.gouv.vitam.tools.sedalib.metadata.SEDAMetadata;
 import fr.gouv.vitam.tools.sedalib.metadata.content.Gps;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
@@ -63,21 +63,21 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     /**
      * The Sub type metadata ordered list map by versions.
      */
-    protected static HashMap<Class<?>, List<String>>[] subTypeMetadataOrderedListMap = new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
+    protected static HashMap<Class<?>, List<String>>[] subTypeMetadataOrderedListMap = new HashMap[SEDA2Version.MAX_SUPPORTED_VERSION+2];
     /**
      * The Sub type metadata map map by versions.
      */
     protected static HashMap<Class<?>, LinkedHashMap<String, ComplexListMetadataKind>>[] subTypeMetadataMapMap =
-            new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
+            new HashMap[SEDA2Version.MAX_SUPPORTED_VERSION+2];
     /**
      * The Sub type expandable map by versions.
      */
     protected static HashMap<Class<?>, Boolean>[] subTypeNotExpandableMap =
-            new HashMap[Seda2Version.MAX_SUPPORTED_VERSION+2];
+            new HashMap[SEDA2Version.MAX_SUPPORTED_VERSION+2];
 
     // init empty maps for all versions (index=version+1) and non specific one (index=0)
     static {
-        for (int i=0;i<Seda2Version.MAX_SUPPORTED_VERSION+2;i++){
+        for (int i = 0; i< SEDA2Version.MAX_SUPPORTED_VERSION+2; i++){
             subTypeMetadataOrderedListMap[i]=new HashMap<>();
             subTypeMetadataMapMap[i]=new HashMap<>();
             subTypeNotExpandableMap[i]=new HashMap<>();
@@ -422,7 +422,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
         if (fields.isEmpty())
             throw new SEDALibException("Le type " + subClass +
                     " n'a pas de variable annotée @ComplexListMetadataMap accessible");
-        else if (fields.size() > Seda2Version.MAX_SUPPORTED_VERSION)
+        else if (fields.size() > SEDA2Version.MAX_SUPPORTED_VERSION)
             throw new SEDALibException("Le type " + subClass +
                     " a un trop grand nombre de variables annotées @ComplexListMetadataMap accessibles");
 
@@ -462,7 +462,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     public List<String> getMetadataOrderedList() throws SEDALibException {
         if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-        List<String> metadataOrderedList = subTypeMetadataOrderedListMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        List<String> metadataOrderedList = subTypeMetadataOrderedListMap[SEDA2Version.getSeda2Version()+1].get(this.getClass());
         if (metadataOrderedList == null)
             metadataOrderedList = subTypeMetadataOrderedListMap[0].get(this.getClass());
         return metadataOrderedList;
@@ -479,7 +479,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     public HashMap<String, ComplexListMetadataKind> getMetadataMap() throws SEDALibException {
         if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[SEDA2Version.getSeda2Version()+1].get(this.getClass());
         if (metadataMap == null)
             metadataMap = subTypeMetadataMapMap[0].get(this.getClass());
         return metadataMap;
@@ -496,7 +496,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     public static HashMap<String, ComplexListMetadataKind> getMetadataMap(Class<?> complexListTypeMetadataClass) throws SEDALibException {
         if (!analyzedSubTypeMetadataSet.contains(complexListTypeMetadataClass))
             getNewComplexListSubType(complexListTypeMetadataClass);
-        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[Seda2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
+        HashMap<String, ComplexListMetadataKind> metadataMap = subTypeMetadataMapMap[SEDA2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
         if (metadataMap == null)
             metadataMap = subTypeMetadataMapMap[0].get(complexListTypeMetadataClass);
         return metadataMap;
@@ -512,7 +512,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     public boolean isNotExpendable() throws SEDALibException {
         if (!analyzedSubTypeMetadataSet.contains(this.getClass()))
             getNewComplexListSubType(this.getClass());
-        Boolean isNotExpandable = subTypeNotExpandableMap[Seda2Version.getSeda2Version()+1].get(this.getClass());
+        Boolean isNotExpandable = subTypeNotExpandableMap[SEDA2Version.getSeda2Version()+1].get(this.getClass());
         if (isNotExpandable == null)
             isNotExpandable = subTypeNotExpandableMap[0].get(this.getClass());
          return isNotExpandable;
@@ -528,7 +528,7 @@ public abstract class ComplexListType extends NamedTypeMetadata {
     public static Boolean isNotExpendable(Class<?> complexListTypeMetadataClass) throws SEDALibException {
         if (!analyzedSubTypeMetadataSet.contains(complexListTypeMetadataClass))
             getNewComplexListSubType(complexListTypeMetadataClass);
-        Boolean isNotExpandable = subTypeNotExpandableMap[Seda2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
+        Boolean isNotExpandable = subTypeNotExpandableMap[SEDA2Version.getSeda2Version()+1].get(complexListTypeMetadataClass);
         if (isNotExpandable == null)
             isNotExpandable = subTypeNotExpandableMap[0].get(complexListTypeMetadataClass);
         return isNotExpandable;

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/LinkingAgentIdentifierType.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/namedtype/LinkingAgentIdentifierType.java
@@ -1,0 +1,52 @@
+package fr.gouv.vitam.tools.sedalib.metadata.namedtype;
+
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class LinkingAgentIdentifierType extends ComplexListType {
+    /**
+     * Init metadata map.
+     */
+    @ComplexListMetadataMap(seda2Version = 2)
+    public static final Map<String, ComplexListMetadataKind> metadataMap;
+
+    static {
+        metadataMap = new LinkedHashMap<>();
+        metadataMap.put("LinkingAgentIdentifierType", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap.put("LinkingAgentIdentifierValue", new ComplexListMetadataKind(StringType.class, false));
+        metadataMap.put("LinkingAgentRole", new ComplexListMetadataKind(StringType.class, false));
+    }
+
+    /**
+     * Instantiates a new linking agent identifier type.
+     *
+     * @param elementName the element name
+     */
+    public LinkingAgentIdentifierType(String elementName) {
+        super(elementName);
+    }
+
+    /**
+     * Instantiates a new linking agent identifier with type, value and role.
+     *
+     * @param elementName                 the element name
+     * @param linkingAgentIdentifierType  the linking agent identifier type
+     * @param linkingAgentIdentifierValue the linking agent identifier value
+     * @param linkingAgentRole            the linking agent role
+     * @throws SEDALibException if sub elements construction is not possible (not supposed to occur)
+     */
+    public LinkingAgentIdentifierType(String elementName,
+                                      String linkingAgentIdentifierType,
+                                      String linkingAgentIdentifierValue,
+                                      String linkingAgentRole) throws SEDALibException{
+        super(elementName);
+        if (linkingAgentIdentifierType!=null)
+            addNewMetadata("LinkingAgentIdentifierType", linkingAgentIdentifierType);
+        if (linkingAgentIdentifierValue!=null)
+            addNewMetadata("LinkingAgentIdentifierValue", linkingAgentIdentifierValue);
+        if (linkingAgentRole!=null)
+            addNewMetadata("LinkingAgentRole", linkingAgentRole);
+    }
+}

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/package-info.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/metadata/package-info.java
@@ -1,5 +1,7 @@
 /**
  * Package for SEDA structure objects (DataObjectPackage, ArchiveUnits and DataObjects) metadata with serialization to and
- * deserilization from XML
+ * deserilization from XML.<P>
+ * <B>Warning</B>: It's possible to choose the SEDA2.x version used but this library is not compliant for parallel use with objects in different versions.
+ *
  */
 package fr.gouv.vitam.tools.sedalib.metadata;

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/xml/IndentXMLTool.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/xml/IndentXMLTool.java
@@ -24,7 +24,7 @@
  * <p>
  * The fact that you are presently reading this means that you have had knowledge of the CeCILL 2.1 license and that you
  * accept its terms.
- */
+ **/
 package fr.gouv.vitam.tools.sedalib.xml;
 
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
@@ -159,7 +159,7 @@ public class IndentXMLTool {
 
         DocumentBuilder appDocumentBuilder;
         try {
-            appDocumentBuilder = dbf.newDocumentBuilder();
+            appDocumentBuilder = dbf.newDocumentBuilder(); // NOSONAR no Doctype risk as all is encapsulated in a <INDENT> tag
             Document doc = appDocumentBuilder.parse(new InputSource(new StringReader("<INDENT>" + xml + "</INDENT>")));
             XPath xPath = xpf.newXPath();
             NodeList nodeList = (NodeList) xPath.evaluate("//text()[normalize-space()='']", doc, XPathConstants.NODESET);
@@ -180,16 +180,16 @@ public class IndentXMLTool {
             while (result.startsWith("\n"))
                 result = result.substring(1);
 
-            Scanner s = new Scanner(result);
             StringBuilder sb = new StringBuilder();
             String tmp;
-            while (s.hasNextLine()) {
-                tmp = s.nextLine();
-                if (tmp.startsWith(indentElement))
-                    tmp = tmp.substring(indentLength);
-                sb.append(tmp).append('\n');
+            try (Scanner s = new Scanner(result)) {
+                while (s.hasNextLine()) {
+                    tmp = s.nextLine();
+                    if (tmp.startsWith(indentElement) && tmp.trim().startsWith("<"))
+                        tmp = tmp.substring(indentLength);
+                    sb.append(tmp).append('\n');
+                }
             }
-            s.close();
             if (sb.length() > 1)
                 sb.setLength(sb.length() - 1);
             return sb.toString();

--- a/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/xml/SEDAXMLValidator.java
+++ b/sedalib/src/main/java/fr/gouv/vitam/tools/sedalib/xml/SEDAXMLValidator.java
@@ -1,5 +1,6 @@
 package fr.gouv.vitam.tools.sedalib.xml;
 
+import fr.gouv.vitam.tools.sedalib.core.SEDA2Version;
 import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
 import org.apache.xerces.util.XMLCatalogResolver;
 import org.xml.sax.SAXException;
@@ -23,7 +24,8 @@ import java.util.Scanner;
 
 public class SEDAXMLValidator {
 
-    private static final String SEDA_VITAM_VALIDATION_RESOURCE = "seda-vitam-2.1-main.xsd";
+    private static final String SEDA_VITAM_VALIDATION_RESOURCE_2_1 = "seda-vitam-2.1-main.xsd";
+    private static final String SEDA_VITAM_VALIDATION_RESOURCE_2_2 = "seda-2.2-main.xsd";
     private static final String HTTP_WWW_W3_ORG_XML_XML_SCHEMA_V1_1 = "http://www.w3.org/XML/XMLSchema/v1.1";
     private static final String CATALOG_FILENAME = "xsd_validation/catalog.xml";
     private static final String RNG_FACTORY = "com.thaiopensource.relaxng.jaxp.XMLSyntaxSchemaFactory";
@@ -31,9 +33,22 @@ public class SEDAXMLValidator {
 
     private static Schema sedaSchema = null;
 
+    public static void resetSEDASchema() {
+        sedaSchema = null;
+    }
+
     public Schema getSEDASchema() throws SEDALibException {
         if (sedaSchema == null)
-            sedaSchema = getSchemaFromXSDResource(getClass().getClassLoader().getResource(SEDA_VITAM_VALIDATION_RESOURCE));
+            switch (SEDA2Version.getSeda2Version()) {
+                case 1:
+                    sedaSchema = getSchemaFromXSDResource(getClass().getClassLoader().getResource(SEDA_VITAM_VALIDATION_RESOURCE_2_1));
+                    break;
+                case 2:
+                    sedaSchema = getSchemaFromXSDResource(getClass().getClassLoader().getResource(SEDA_VITAM_VALIDATION_RESOURCE_2_2));
+                    break;
+                default:
+                    throw new SEDALibException("Version active du SEDA ["+ SEDA2Version.getSeda2VersionString()+"] sans schéma",null);
+            }
         return sedaSchema;
     }
 

--- a/sedalib/src/main/resources/DiffSeda2.2vs2.1.txt
+++ b/sedalib/src/main/resources/DiffSeda2.2vs2.1.txt
@@ -1,0 +1,62 @@
+Comparaison 2.1 vs 2.2
+
+- management
+	* ajout HoldRule (était dans Vitam)
+	doc :
+	        Gestion de la durée de gel des ArchiveUnits.
+            La date de fin de gel est calculée à partir d'une date de début de restriction (StardDate) et de la durée de validité de la règle de réference. Elle peut également être explicitement spécifiée (HoldEndDate) si la règle de référence ne spécifie pas de durée déterminée.
+            Si la règle ne possède pas de durée de fin (calculée ou explicite), alors la règle est réputée à durée indéterminée (restriction toujours effective)
+			La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.
+
+	<HoldRule>
+			(<Rule> ID <Rule>
+			<StartDate> date <StartDate>?
+			<HoldEndDate> date <HoldEndDate>?
+			<HoldOwner> string <HoldOwner>?
+			<HoldReassessingDate> date <HoldReassessingDate>?
+			<HoldReason> string <HoldReason>?
+			<PreventRearrangement> boolean <PreventRearrangement>?)*
+			<PreventInheritance>true</PreventInheritance>
+			<RefNonRuleId>a</RefNonRuleId>
+	</HoldRule>
+
+
+- ontology
+	* ajout DateLitteral
+	doc:
+			Champ date en texte libre.
+
+	<DateLitteral> string </DateLitteral>
+
+	* ajout dans Event de  LinkingAgentIdentifier
+	doc:
+		Permet de renseigner des agents répertoriés dans des évènements.
+
+
+	<LinkingAgentIdentifier>
+        <LinkingAgentIdentifierType> string </LinkingAgentIdentifier>
+		<LinkingAgentIdentifierValue> string </LinkingAgentIdentifierValue>
+		<LinkingAgentRole> string </LinkingAgentRole>
+
+	* ajout de la notion d'Agent générique et non abstrait qui était difficilement utilisable avant AuthorizedAgent
+	doc:
+		Agent générique.
+
+	<Agent> AgentType </Agent>
+
+	* ajout OriginatingSystemIdReplyToGroup optionnel avant TextContent(était dans Vitam)
+	doc:
+		Référence du message auquel on répond.
+	<OriginatingSystemIdReplyToGroup> string </OriginatingSystemIdReplyToGroup>
+
+
+	* ajout de TextContent optionnel avant l'extension brute
+	doc:
+		Contenu du message électronique.
+	<TextContent> string </TextContent>
+
+- technique
+	ajout de DataObjectProfile optionnel devant DataObjectSystemId
+	doc:
+		Référence à une partie d'un profil d’archivage applicable à un objet technique en particulier.
+	<DataObjectProfile> String </DataObjectProfile>

--- a/sedalib/src/main/resources/Seda2.2.md
+++ b/sedalib/src/main/resources/Seda2.2.md
@@ -1,0 +1,24 @@
+# Standard d'échange de données pour l'archivage (SEDA)
+Cette version 2.2 du Standard d'échanges de données pour l'archivage (SEDA) publiée en janvier 2022 sous l'égide du Service interministériel des Archives de France,
+comprend six schémas et un dictionnaire.
+Ils sont le fruit du travail mené en 2020-2021 par le Comité de pilotage du SEDA, qui rassemble des acteurs œuvrant pour l’utilisation de ce standard d'échange
+dans les services publics d’archives, chez les tiers-archiveurs, les éditeurs de logiciels d’archivage électronique ou encore les cabinets spécialisés dans
+l'accompagnement de projets d'archivage électronique.
+
+Le SEDA modélise 6 transactions qui peuvent avoir lieu entre des acteurs dans le cadre de l'archivage de données :
+le transfert, la demande de transfert, la modification, l'élimination, la communication et la restitution.
+Les présents schémas traduisent formellement la forme des messages échangés au cours des transactions.
+Ils ont été réalisés par le Cabinet Mintika à partir des principes définis en Comité de pilotage.
+Les principaux changements par rapport à la version 2.1 publiée en juin 2018 sur https://francearchives.fr/seda/
+sont:
+- Modification de AgentType générique dans l’ontologie;
+- Dépréciation de AgentAbstract;
+- Ajout d'une nouvelle règle de gestion HoldRule dans les métadonnées de gestion;
+- Ajout de HoldRuleCodeListVersion;
+- Ajout de OriginatingSystemIdReplyToGroup et de TextContent (pour les mails);
+- Ajout de LinkingAgentIdentifierType dans les Event;
+- Ajout de DataObjectProfile dans les métadonnées techniques;
+- Ajout de DateLitteral dans l’ontologie;
+- Modification du type de MessageIdentifier (devient NonEmptyToken).
+
+Le dictionnaire des balises SEDA est proposé quant à lui dans une version de travail. Il synthétise par grands ensembles de métadonnées (gestion, description, technique, transport et typologie de messages) les éléments présents dans les schémas du standard. 

--- a/sedalib/src/main/resources/seda-2.2-descriptive.xsd
+++ b/sedalib/src/main/resources/seda-2.2-descriptive.xsd
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="fr:gouv:culture:archivesdefrance:seda:v2.2" xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xlink="http://www.w3.org/1999/xlink" xmlns="fr:gouv:culture:archivesdefrance:seda:v2.2"
+    elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.0">
+    <xsd:include schemaLocation="seda-2.2-types.xsd"/>
+    <xsd:include schemaLocation="seda-2.2-management.xsd"/>
+    <xsd:include schemaLocation="seda-2.2-ontology.xsd"/>
+    
+    <!-- Hierarchy and recursivity -->
+    <xsd:complexType name="ArchiveUnitType">
+        <xsd:annotation>
+            <xsd:documentation>Unité de base des métadonnées de description contenant la gestion de l'arborescence.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice>
+            <xsd:element name="ArchiveUnitRefId" type="ArchiveUnitRefIdType">
+                <xsd:annotation>
+                    <xsd:documentation>Permet de faire une référence à d'autres ArchiveUnit dans la même transaction.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:sequence>
+                <xsd:element name="ArchiveUnitProfile" type="IdentifierType" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à une partie d'un profil d’archivage applicable à un ArchiveUnit en particulier. Permet par exemple de faire référence à une typologie documentaire dans un profil d'archivage.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="Management" type="ManagementType" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Métadonnées de gestion applicables à l’ArchiveUnit concernée et à ses héritiers.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="Content" type="DescriptiveMetadataContentType" minOccurs="1">
+                    <xsd:annotation>
+                        <xsd:documentation>Métadonnées de description associées à un ArchiveUnit.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <!-- Hierarchy -->
+                    <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                        <xsd:element name="ArchiveUnit" type="ArchiveUnitType">
+                            <xsd:annotation>
+                                <xsd:documentation>Gestion de la récursivité. Une ArchiveUnit peut être contenu dans une ature ArchiveUnit.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element ref="ArchiveUnitReferenceAbstract">
+                            <xsd:annotation>
+                                <xsd:documentation>Permet de faire référence à une sous unité d'archives, pouvant être déjà présente dans le système d'archivage provenant d'une transaction précédente.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                        <xsd:element name="DataObjectReference" type="DataObjectRefType">
+                            <xsd:annotation>
+                                <xsd:documentation>Permet de faire référence à un objet-donnée binaire ou physique déjà présent dans les métadonnées du bordereau.</xsd:documentation>
+                            </xsd:annotation>
+                        </xsd:element>
+                    </xsd:choice>
+            </xsd:sequence>
+        </xsd:choice>
+        <xsd:attribute name="id" type="ArchiveUnitIdType" use="required">
+            <xsd:annotation>
+                <xsd:documentation>Identifiant de l'unité d'archives utilisé par exemple dans le cas de multiples héritages, pour savoir quel noeud contient une erreur.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+    <xsd:complexType name="ManagementType">
+        <xsd:group ref="ManagementGroup"/>
+    </xsd:complexType>
+
+    <!-- In ArchiveUnitType from seda-2.2-descriptive.xsd: Descriptive Metadata Content -->
+    <xsd:complexType name="DescriptiveMetadataContentType">
+        <xsd:annotation>
+            <xsd:documentation>Permet de définir les métadonnées de description. Peut être étendu.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:group ref="ObjectGroup"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+</xsd:schema>

--- a/sedalib/src/main/resources/seda-2.2-main.xsd
+++ b/sedalib/src/main/resources/seda-2.2-main.xsd
@@ -1,0 +1,980 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="fr:gouv:culture:archivesdefrance:seda:v2.2"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns="fr:gouv:culture:archivesdefrance:seda:v2.2" elementFormDefault="qualified"
+    attributeFormDefault="unqualified" version="1.0">
+
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace"
+        schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+    <xsd:import namespace="http://www.w3.org/1999/xlink"
+        schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
+
+    <!--
+                *****************************
+                ***   Types de base
+                *****************************
+        -->
+    <xsd:include schemaLocation="seda-2.2-types.xsd"/>
+    <!--
+                *****************************
+                ***   Base technique
+                *****************************
+        -->
+    <xsd:include schemaLocation="seda-2.2-technical.xsd"/>
+    <!--
+                *****************************
+                ***   Base de gestion
+                *****************************
+        -->
+    <xsd:include schemaLocation="seda-2.2-management.xsd"/>
+    <!--
+                *****************************
+                ***   Base descriptive
+                *****************************
+        -->
+    <xsd:include schemaLocation="seda-2.2-descriptive.xsd"/>
+
+    <!--
+                *****************************
+                ***   Code List
+                *****************************
+ 
+        -->
+    <!-- Liste des versions des référentiels issue de MEDONA -->
+    <xsd:group name="TransportCodeListsGroup">
+        <xsd:annotation>
+            <xsd:documentation>Liste des codes de réponses souhaitée par
+                l'expéditeur.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:group ref="ReplyCodeListGroup"/>
+        </xsd:sequence>
+    </xsd:group>
+    <!-- Reply Code list -->
+    <xsd:group name="ReplyCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="ReplyCodeListVersion" type="CodeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Liste des codes de réponses à utiliser.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="ReplyCodeType">
+        <xsd:annotation>
+            <xsd:documentation>Code de réponses spécifié dans la liste de
+                réponses.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType"/>
+    </xsd:simpleType>
+
+
+    <!-- Liste des versions des référentiels utilisés globalement -->
+    <xsd:complexType name="CodeListVersionsType">
+        <xsd:sequence>
+            <xsd:group ref="TransportCodeListsGroup"/>
+            <xsd:group ref="TechnicalCodeListsGroup"/>
+            <xsd:group ref="ManagementCodeListsGroup"/>
+            <xsd:element name="AcquisitionInformationCodeListVersion" type="CodeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Version de la liste de codes des modalités
+                        d'entrée.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="AuthorizationReasonCodeListVersion" type="CodeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Version de la liste de codes
+                        d'autorisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="RelationshipCodeListVersion" type="CodeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Version de la liste de codes des
+                        relations.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="OtherCodeListAbstract" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Permet d'ajouter de nouvelles listes de codes si l'ajout
+                        d'autres métadonnées l'impose.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute ref="xml:id" use="optional"/>
+    </xsd:complexType>
+
+    <!--
+                *****************************
+                ***   Types métier
+                *****************************
+ 
+        -->
+
+    <!-- Groupe d'objets-données SEDA 2.2 -->
+    <xsd:complexType name="DataObjectGroupType">
+        <xsd:sequence>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="BinaryDataObject" type="BinaryDataObjectType">
+                    <xsd:annotation>
+                        <xsd:documentation>Bloc de métadonnées techniques des objets-données
+                            numériques. Le caractère facultatif est requis afin de permettre le
+                            transfert d'un plan de classement sans DataObject
+                            joint.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="PhysicalDataObject" type="PhysicalDataObjectType">
+                    <xsd:annotation>
+                        <xsd:documentation>Bloc de métadonnées techniques des objets-données
+                            physiques.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="LogBook" type="LogBookOgType" minOccurs="0"/>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="GroupIdType" use="required"/>
+    </xsd:complexType>
+    <xsd:complexType name="LogBookOgType">
+        <xsd:sequence>
+            <xsd:element name="Event" type="EventLogBookOgType" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="EventLogBookOgType">
+        <xsd:complexContent>
+            <xsd:extension base="EventType">
+                <xsd:sequence>
+                    <xsd:element name="DataObjectReferenceId" type="DataObjectRefIdType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Permet de faire référence à un objet-donnée binaire ou physique déjà présent dans les métadonnées du bordereau.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Paquet d'Objets-données -->
+    <xsd:complexType name="DataObjectPackageType">
+        <xsd:sequence>
+            <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="DataObjectGroup" type="DataObjectGroupType"/>
+                <xsd:choice minOccurs="0" maxOccurs="unbounded">
+                    <xsd:element name="BinaryDataObject" type="BinaryDataObjectType">
+                        <xsd:annotation>
+                            <xsd:documentation>Bloc de métadonnées techniques des objets-données
+                                numériques. Le caractère facultatif est requis afin de permettre le
+                                transfert d'un plan de classement sans DataObject
+                                joint.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="PhysicalDataObject" type="PhysicalDataObjectType">
+                        <xsd:annotation>
+                            <xsd:documentation>Bloc de métadonnées techniques des objets-données
+                                physiques.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:choice>
+            </xsd:choice>
+            <xsd:element name="DescriptiveMetadata" type="DescriptiveMetadataType">
+                <xsd:annotation>
+                    <xsd:documentation>Bloc de métadonnées descriptives des
+                        objets-données.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ManagementMetadata" type="ManagementMetadataType">
+                <xsd:annotation>
+                    <xsd:documentation>Bloc des métadonnées de gestion par défaut des
+                        objets-données.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute ref="xml:id" use="optional"/>
+    </xsd:complexType>
+
+    <!-- Métadonnées de gestion -->
+    <xsd:complexType name="ManagementMetadataType">
+        <xsd:sequence>
+            <xsd:element name="ArchivalProfile" type="IdentifierType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Profil d’archivage applicable aux
+                        ArchiveUnit.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ServiceLevel" type="IdentifierType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Niveau de service applicable aux unités
+                        d’archives.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="AcquisitionInformation" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Modalités d'entrée des archives.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="LegalStatus" type="LegalStatusType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Statut des archives échangées.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="OriginatingAgencyIdentifier" type="IdentifierType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant du service producteur - information de gestion à
+                        ne pas confondre avec OriginatingAgency dans les métadonnées de
+                        description.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="SubmissionAgencyIdentifier" type="IdentifierType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant du service versant - information de gestion à ne
+                        pas confondre avec SubmissionAgency dans les métadonnées de
+                        description.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:group ref="ManagementGroup" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées de gestion associées à l'ensemble des unités
+                        d'archives.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:group>
+        </xsd:sequence>
+        <xsd:attribute ref="xml:id" use="optional"/>
+    </xsd:complexType>
+
+
+    <!-- ========================================================= -->
+    <!-- ===== Code List LegalStatusType: LegalStatus Code ======= -->
+    <!-- ========================================================= -->
+    <xsd:simpleType name="LegalStatusType">
+        <xsd:annotation>
+            <xsd:documentation>Valeurs de LegalStatus.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="Public Archive"/>
+            <xsd:enumeration value="Private Archive"/>
+            <xsd:enumeration value="Public and Private Archive"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- Demande d'autorisation -->
+    <xsd:complexType name="AuthorizationRequestContentType">
+        <xsd:sequence>
+            <xsd:element name="AuthorizationReason" type="xsd:token">
+                <xsd:annotation>
+                    <xsd:documentation>Motif de l'autorisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Comment" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Commentaire sur la transaction.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="RequestDate" type="xsd:date">
+                <xsd:annotation>
+                    <xsd:documentation>Date de la demande d'autorisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="UnitIdentifier" type="IdentifierType" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant de l'unité documentaire.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Requester" type="OrganizationType">
+                <xsd:annotation>
+                    <xsd:documentation>Demandeur de l'autorisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="AuthorizationRequestReply"
+                type="BusinessAuthorizationRequestReplyMessageType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Réponse à la demande d’autorisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute ref="xml:id" use="optional"/>
+    </xsd:complexType>
+
+    <!--
+                ***************************** 
+                ***   Base de l'arborescence
+                *****************************
+        -->
+
+    <!-- Métadonnées descriptives pour un paquet d'Objets-données -->
+    <xsd:complexType name="DescriptiveMetadataType">
+        <xsd:sequence>
+            <xsd:element name="ArchiveUnit" type="ArchiveUnitType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Correspond à la notion de composant en ISAD(G). ArchiveUnit
+                        permet à la fois de gérer la hiérarchie intellectuelle, tout en contenant
+                        les métadonnées de description et de gestion propres à chaque niveau de
+                        description archivistique.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!--
+                *****************************
+                ***   Déclaration des types de message
+                *****************************
+        -->
+
+    <!-- Message -->
+    <xsd:complexType name="MessageType" abstract="true">
+        <xsd:sequence>
+            <xsd:element name="Comment" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Commentaire sur le message.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Date" type="xsd:dateTime">
+                <xsd:annotation>
+                    <xsd:documentation>Date du message.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="MessageIdentifier" type="IdentifierType">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant du message.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Signature" type="SignatureMessageType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Signature du message.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute ref="xml:id" use="optional"/>
+    </xsd:complexType>
+
+
+    <!-- Message métier -->
+    <xsd:complexType name="BusinessMessageType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="MessageType">
+                <xsd:sequence>
+                    <xsd:element name="ArchivalAgreement" type="IdentifierType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Accord de service.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="CodeListVersions" type="CodeListVersionsType">
+                        <xsd:annotation>
+                            <xsd:documentation>Listes de codes de références utilisés dans le
+                                message.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="DataObjectPackage" type="DataObjectPackageType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Objets-données échangés dans le
+                                message.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Message de demande -->
+    <xsd:complexType name="BusinessRequestMessageType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessMessageType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Message de demande d'autorisation -->
+    <xsd:complexType name="BusinessAuthorizationRequestMessageType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessRequestMessageType">
+                <xsd:sequence>
+                    <xsd:element name="AuthorizationRequestContent"
+                        type="AuthorizationRequestContentType">
+                        <xsd:annotation>
+                            <xsd:documentation>Demande d’autorisation.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Message de reponse à une demande -->
+    <xsd:complexType name="BusinessReplyMessageType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessMessageType">
+                <xsd:sequence>
+                    <xsd:element name="ReplyCode" type="NonEmptyTokenType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Code de la réponse.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Operation" type="OperationType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Liste des événements dans les messages de
+                                réponse</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="MessageRequestIdentifier" type="IdentifierType">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de la demande.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Liste des opérations dans les messages de réponse  -->
+    <xsd:complexType name="OperationType">
+        <xsd:sequence>
+            <xsd:element name="Event" type="EventType" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- Message de demande d'autorisation -->
+    <xsd:complexType name="BusinessAuthorizationRequestReplyMessageType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessReplyMessageType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Message de notification -->
+    <xsd:complexType name="BusinessNotificationMessageType" abstract="true">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessMessageType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Défintion des organisations avec Id -->
+    <xsd:complexType name="OrganizationWithIdType">
+        <xsd:complexContent>
+            <xsd:extension base="OrganizationType">
+                <xsd:attribute ref="xml:id" use="optional"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+
+    <!--
+                *****************************
+                ***   Le message d'accusé de réception
+                *****************************
+        -->
+    <xsd:element name="Acknowledgement" type="AcknowledgementType">
+        <xsd:annotation>
+            <xsd:documentation>Accusé de réception d'un message.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="AcknowledgementType">
+        <xsd:complexContent>
+            <xsd:extension base="MessageType">
+                <xsd:sequence>
+                    <xsd:element name="MessageReceivedIdentifier" type="IdentifierType">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant du message reçu.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Sender" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Expéditeur du message.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Receiver" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Destinataire du message.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!--
+                *****************************
+                ***   Les messages de requete
+                *****************************
+        -->
+    <!-- Message de demande de communication -->
+    <xsd:element name="ArchiveDeliveryRequest" type="ArchiveDeliveryRequestType">
+        <xsd:annotation>
+            <xsd:documentation>Demande de communication d'archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveDeliveryRequestType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessRequestMessageType">
+                <xsd:sequence>
+                    <xsd:element name="Derogation" type="xsd:boolean">
+                        <xsd:annotation>
+                            <xsd:documentation>Indique si une procédure de dérogation est nécessaire
+                                avant de communiquer l’unité d'archive.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="UnitIdentifier" type="IdentifierType" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de l'unité d'archive.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la
+                                communication.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Requester" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Demandeur de la communication.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de demande de restitution -->
+    <xsd:element name="ArchiveRestitutionRequest" type="ArchiveRestitutionRequestType">
+        <xsd:annotation>
+            <xsd:documentation>Demande de restitution d'archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveRestitutionRequestType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessRequestMessageType">
+                <xsd:sequence>
+                    <xsd:element name="UnitIdentifier" type="IdentifierType" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de l'unité
+                                d'archives.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la
+                                restitution.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="OriginatingAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service producteur demandant la
+                                restitution.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de transfert (attention le paquet de données est facultatif)-->
+    <xsd:element name="ArchiveTransfer" type="ArchiveTransferType">
+        <xsd:annotation>
+            <xsd:documentation>Transfert d'archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveTransferType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessRequestMessageType">
+                <xsd:sequence>
+                    <xsd:element name="RelatedTransferReference" type="IdentifierType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant d’un transfert
+                                associé.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="TransferRequestReplyIdentifier" type="IdentifierType"
+                        minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de la réponse à une demande de
+                                transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable du
+                                transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="TransferringAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service versant chargé de réaliser le
+                                transport.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de demande de transfert -->
+    <xsd:element name="ArchiveTransferRequest" type="ArchiveTransferRequestType">
+        <xsd:annotation>
+            <xsd:documentation>Demande de transfert d’archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveTransferRequestType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessRequestMessageType">
+                <xsd:sequence>
+                    <xsd:element name="RelatedTransferReference" type="IdentifierType" minOccurs="0"
+                        maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Référence à un transfert d'archives
+                                lié.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="TransferDate" type="xsd:dateTime" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Date retenue pour le transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable du
+                                transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="TransferringAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service versant responsable du
+                                transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!--
+                *****************************
+                ***   Les messages de demande d'autorisation
+                *****************************
+        -->
+    <!-- Message de demande d'autorisation au service de contrôle -->
+    <xsd:element name="AuthorizationControlAuthorityRequest"
+        type="AuthorizationControlAuthorityRequestType">
+        <xsd:annotation>
+            <xsd:documentation>Demande d'autorisation au service de contrôle.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="AuthorizationControlAuthorityRequestType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessAuthorizationRequestMessageType">
+                <xsd:sequence>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la demande
+                                d'autorisation.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ControlAuthority" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Autorité de contrôle.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de demande d'autorisation au service producteur -->
+    <xsd:element name="AuthorizationOriginatingAgencyRequest"
+        type="AuthorizationOriginatingAgencyRequestType">
+        <xsd:annotation>
+            <xsd:documentation>Demande d'autorisation au service producteur.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="AuthorizationOriginatingAgencyRequestType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessAuthorizationRequestMessageType">
+                <xsd:sequence>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la demande
+                                d'autorisation.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="OriginatingAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service producteur responsable de l’instruction de la
+                                demande d’autorisation.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!--
+                ***************************** 
+				                ***   Les messages de reponse à une requete
+                *****************************
+        -->
+    <!-- Message de réponse à une demande de communication -->
+    <xsd:element name="ArchiveDeliveryRequestReply" type="ArchiveDeliveryRequestReplyType">
+        <xsd:annotation>
+            <xsd:documentation>Réponse à une demande de communication
+                d'archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveDeliveryRequestReplyType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessReplyMessageType">
+                <xsd:sequence>
+                    <xsd:element name="AuthorizationRequestReplyIdentifier" type="IdentifierType"
+                        minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de la réponse à une demande
+                                d’autorisation.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="UnitIdentifier" type="IdentifierType" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de l'unité d'archive.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la demande de
+                                communication.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Requester" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Demandeur de la communication.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de réponse à une demande de restitution -->
+    <xsd:element name="ArchiveRestitutionRequestReply" type="ArchiveRestitutionRequestReplyType">
+        <xsd:annotation>
+            <xsd:documentation>Réponse à une demande de restitution d'archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveRestitutionRequestReplyType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessReplyMessageType">
+                <xsd:sequence>
+                    <xsd:element name="UnitIdentifier" type="IdentifierType" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de l'unité d'archive.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la demande de
+                                restitution.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="OriginatingAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service producteur responsable de la demande de
+                                restitution.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de réponse à un transfert -->
+    <xsd:element name="ArchiveTransferReply" type="ArchiveTransferReplyType">
+        <xsd:annotation>
+            <xsd:documentation>Réponse à un transfert d'archives (acceptation, rejet,
+                anomalie...).</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveTransferReplyType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessReplyMessageType">
+                <xsd:sequence>
+                    <xsd:element name="GrantDate" type="xsd:dateTime" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Date de prise en charge effective du
+                                transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la réponse à un
+                                transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="TransferringAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service versant responsable de la réponse à un
+                                transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de réponse à une demande de transfert -->
+    <xsd:element name="ArchiveTransferRequestReply" type="ArchiveTransferRequestReplyType">
+        <xsd:annotation>
+            <xsd:documentation>Réponse à une demande de transfert d’archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveTransferRequestReplyType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessReplyMessageType">
+                <xsd:sequence>
+                    <xsd:element name="TransferDate" type="xsd:dateTime" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Date de transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la réponse à une
+                                demande de transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="TransferringAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service versant responsable de la réponse à une
+                                demande de transfert.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!--
+                *****************************
+                ***   Les messages de reponse à une demande d'autorisation
+                *****************************
+        -->
+    <!-- Message de réponse à une demande d'autorisation au service de contrôle -->
+    <xsd:element name="AuthorizationControlAuthorityRequestReply"
+        type="AuthorizationControlAuthorityRequestReplyType">
+        <xsd:annotation>
+            <xsd:documentation>Réponse donnée à une demande d'autorisation au service de
+                contrôle.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="AuthorizationControlAuthorityRequestReplyType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessAuthorizationRequestReplyMessageType">
+                <xsd:sequence>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la réponse à une
+                                demande d'autorisation à un service de contrôle.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ControlAuthority" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service de contrôle responsable de la réponse à une
+                                demande d'autorisation à un service de contrôle.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <!-- Message de réponse à une demande d'autorisation au service producteur -->
+    <xsd:element name="AuthorizationOriginatingAgencyRequestReply"
+        type="AuthorizationOriginatingAgencyRequestReplyType">
+        <xsd:annotation>
+            <xsd:documentation>Réponse donnée à une demande d'autorisation au service
+                producteur.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="AuthorizationOriginatingAgencyRequestReplyType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessAuthorizationRequestReplyMessageType">
+                <xsd:sequence>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d’archives à l’origine de la demande
+                                d’autorisation.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="OriginatingAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service producteur responsable de l’instruction de la
+                                demande d’autorisation.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!--
+                *****************************
+                ***   Les messages de notification
+                *****************************
+        -->
+    <!-- Message de notification d'élimination -->
+    <xsd:element name="ArchiveDestructionNotification" type="ArchiveDestructionNotificationType">
+        <xsd:annotation>
+            <xsd:documentation>Notification d'élimination d'archives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveDestructionNotificationType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessNotificationMessageType">
+                <xsd:sequence>
+                    <xsd:element name="AuthorizationRequestReplyIdentifier" type="IdentifierType">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de la réponse à une demande
+                                d'autorisation d'élimination.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="UnitIdentifier" type="IdentifierType" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de l'unité d'archive.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la notification
+                                d'élimination.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="OriginatingAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service producteur responsable de la notification
+                                d'élimination.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Message de notification de modification -->
+    <xsd:element name="ArchiveModificationNotification" type="ArchiveModificationNotificationType">
+        <xsd:annotation>
+            <xsd:documentation>Notification de modification d'archives (format ou
+                métadonnées).</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    <xsd:complexType name="ArchiveModificationNotificationType">
+        <xsd:complexContent>
+            <xsd:extension base="BusinessNotificationMessageType">
+                <xsd:sequence>
+                    <xsd:element name="UnitIdentifier" type="IdentifierType" maxOccurs="unbounded">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant de l'unité
+                                d'archives.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="ArchivalAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service d'archives responsable de la notification de
+                                modification.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="OriginatingAgency" type="OrganizationWithIdType">
+                        <xsd:annotation>
+                            <xsd:documentation>Service producteur responsable de la notification de
+                                modification.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+</xsd:schema>

--- a/sedalib/src/main/resources/seda-2.2-management.xsd
+++ b/sedalib/src/main/resources/seda-2.2-management.xsd
@@ -1,0 +1,517 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+    targetNamespace="fr:gouv:culture:archivesdefrance:seda:v2.2"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+    xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns="fr:gouv:culture:archivesdefrance:seda:v2.2"
+    elementFormDefault="qualified"
+    attributeFormDefault="unqualified"
+    version="1.0">
+    <xsd:include schemaLocation="seda-2.2-types.xsd"/>
+    
+    <!--
+                *****************************
+                ***   Code List
+                *****************************
+ 
+        -->
+    <xsd:group name="ManagementCodeListsGroup">
+        <xsd:annotation>
+            <xsd:documentation>Listes de codes nécessaires dans les métadonnées de gestion.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:group ref="StorageRuleCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="AppraisalRuleCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="AccessRuleCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="DisseminationRuleCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="ReuseRuleCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="ClassificationRuleCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="HoldRuleCodeListGroup" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Management Lists and Codes -->
+    <xsd:complexType name="RuleIdType">
+        <xsd:annotation>
+            <xsd:documentation>Identifiant de la règle de gestion.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:simpleContent>
+            <xsd:extension base="NonEmptyTokenType">
+                <xsd:attribute name="id" type="xsd:ID" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    
+    <xsd:group name="AccessRuleCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="AccessRuleCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version des listes de codes pour les règles de communicabilité.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <xsd:group name="DisseminationRuleCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="DisseminationRuleCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version des listes de codes pour les règles de diffusion.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <xsd:group name="ReuseRuleCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="ReuseRuleCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version des listes de codes pour les règles de réutilisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <xsd:group name="ClassificationRuleCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="ClassificationRuleCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version des listes de codes pour les règles de classification.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <xsd:group name="AppraisalRuleCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="AppraisalRuleCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version des listes de codes pour les règles de durée d'utilité administrative.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <xsd:group name="StorageRuleCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="StorageRuleCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version des listes de codes pour les règles de durée d'utilité courante.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <xsd:group name="HoldRuleCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="HoldRuleCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version des listes de codes pour les règles de gel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <!-- Management content -->
+    <xsd:group name="ManagementGroup">
+        <xsd:annotation>
+            <xsd:documentation>Contient les métadonnées de gestion.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="StorageRule" type="StorageRuleType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion de la durée d’utilité courante.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="AppraisalRule" type="AppraisalRuleType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion de la durée d’utilité administrative.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="AccessRule" type="AccessRuleType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion de la communicabilité.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="DisseminationRule" type="DisseminationRuleType"
+                minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion de la diffusion.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ReuseRule" type="ReuseRuleType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion de la réutilisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ClassificationRule" type="ClassificationRuleType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion de la classification.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="LogBook" type="LogBookType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion des traces.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="NeedAuthorization" type="xsd:boolean" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Indique si une autorisation humaine est nécessaire pour vérifier ou valider les opérations de gestion des ArchiveUnit.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="HoldRule" type="HoldRuleType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Gestion de la durée de gel des ArchiveUnits.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="OtherManagementAbstract" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Autres métadonnées de gestion.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="LogBookType">
+        <xsd:sequence>
+            <xsd:element name="Event" type="EventType" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:complexType>
+        
+    <!-- Global inheritance control -->
+    <xsd:group name="PreventInheritanceGroup">
+        <xsd:choice>
+            <xsd:element name="PreventInheritance" type="xsd:boolean" default="false" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Indique si les règles de gestion héritées des ArchiveUnit parents doivent être ignorées pour l’ArchiveUnit concerné.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+    </xsd:group>
+    
+    <xsd:complexType name="AccessRuleType">
+        <xsd:annotation>
+            <xsd:documentation>Gestion de la communicabilité.</xsd:documentation>
+            <xsd:documentation>Chaque règle a une startDate et un Identifiant de règle de référence pour la durée.
+                Si aucune règle n'est spécifiée et que la date actuelle est dans la StarDate, la réponse de restriction est "Aucune restriction".
+                Si la date est vide, la réponse de restriction est "Restreint" car il n'y a aucun moyen de calculer la date de fin.
+                Si une règle et une date sont précisées, alors la date de fin d'application de la règle peut être calculée et comparée avec la date courante..</xsd:documentation>
+            <xsd:documentation>La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="Rule" type="RuleIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à la règle de communicabilité.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="StartDate" type="xsd:date" nillable="true" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Date de départ de calcul de la règle de communicabilité.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:choice minOccurs="0">
+                <xsd:group ref="PreventInheritanceGroup"/>
+                <xsd:element name="RefNonRuleId" type="RuleIdType" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>Identifiant de la règle à désactiver à partir de cette ArchiveUnit.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <xsd:complexType name="DisseminationRuleType">
+        <xsd:annotation>
+            <xsd:documentation>Gestion de la diffusion.</xsd:documentation>
+            <xsd:documentation>Chaque règle a une startDate et un Identifiant de règle de référence pour la durée.
+                Si aucune règle n'est spécifiée et que la date actuelle est dans la StarDate, la réponse de restriction est "Aucune restriction".
+                Si la date est vide, la réponse de restriction est "Restreint" car il n'y a aucun moyen de calculer la date de fin.
+                Si une règle et une date sont précisées, alors la règle est valable (restriction appliquée).</xsd:documentation>
+            <xsd:documentation>La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="Rule" type="RuleIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à la règle de diffusion.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="StartDate" type="xsd:date" nillable="true" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Date de départ de calcul de la règle de diffusion.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:choice minOccurs="0">
+                <xsd:group ref="PreventInheritanceGroup"/>
+                <xsd:element name="RefNonRuleId" type="RuleIdType" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>L'identifiant de la règle spécifiée pourra être retirée de l'héritage dans ce noeud.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <xsd:complexType name="ReuseRuleType">
+        <xsd:annotation>
+            <xsd:documentation>Gestion de la réutilisation.</xsd:documentation>
+            <xsd:documentation>Chaque règle a une startDate et un Identifiant de règle de référence pour la durée.
+                Si aucune règle n'est spécifiée et que la date actuelle est dans la StarDate, la réponse de restriction est "Aucune restriction".
+                Si la date est vide, la réponse de restriction est "Restreint" car il n'y a aucun moyen de calculer la date de fin.
+                Si une règle et une date sont précisées, alors la règle est valable (restriction appliquée).</xsd:documentation>
+            <xsd:documentation>La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="Rule" type="RuleIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à la règle de réutilisation.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="StartDate" type="xsd:date" nillable="true" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Date de départ de calcul de la règle de réutilisation.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:choice minOccurs="0">
+                <xsd:group ref="PreventInheritanceGroup"/>
+                <xsd:element name="RefNonRuleId" type="RuleIdType" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>L'identifiant de la règle spécifiée pourra être retirée de l'héritage dans ce noeud.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <xsd:complexType name="ClassificationRuleType">
+        <xsd:annotation>
+            <xsd:documentation>Gestion de la classification.</xsd:documentation>
+            <xsd:documentation>Chaque règle a une startDate et un Identifiant de règle de référence pour la durée.
+                Si aucune règle n'est spécifiée et que la date actuelle est dans la StarDate, la réponse de restriction est "Aucune restriction".
+                Si la date est vide, la réponse de restriction est "Restreint" car il n'y a aucun moyen de calculer la date de fin.
+                Si une règle et une date sont précisées, alors la règle est valable (restriction appliquée).</xsd:documentation>
+            <xsd:documentation>La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="Rule" type="RuleIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à la règle de classification.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="StartDate" type="xsd:date" nillable="true" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Date de départ de calcul de la règle de classification.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:element name="ClassificationAudience" type="NonEmptyTokenType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Permet de gérer les questions de "diffusion restreinte", de "spécial France" et de "Confidentiel Industrie".</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:choice minOccurs="0">
+                <xsd:group ref="PreventInheritanceGroup"/>
+                <xsd:element name="RefNonRuleId" type="RuleIdType" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>L'identifiant de la règle spécifiée pourra être retirée de l'héritage dans ce noeud.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="ClassificationLevel" type="NonEmptyTokenType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence au niveau de classification.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ClassificationOwner" type="NonEmptyTokenType">
+                <xsd:annotation>
+                    <xsd:documentation>Propriétaire de la classification. Service émetteur au sens de l’IGI 1300.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ClassificationReassessingDate" type="xsd:date" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de réévaluation de la classification.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="NeedReassessingAuthorization" type="xsd:boolean" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Indique si une autorisation humaine est nécessaire pour réévaluer la classification.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <xsd:simpleType name="FinalActionStorageCodeType">
+        <xsd:annotation>
+            <xsd:documentation>Code correspondant à l’action à entreprendre au terme de la durée d’utilité courante.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType">
+            <xsd:enumeration value="RestrictAccess"/>
+            <xsd:enumeration value="Transfer"/>
+            <xsd:enumeration value="Copy"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="StorageRuleType">
+        <xsd:annotation>
+            <xsd:documentation>Gestion de la durée d'utilité courante.</xsd:documentation>
+            <xsd:documentation>Chaque règle a une startDate et un Identifiant de règle de référence pour la durée.
+                Si aucune règle n'est spécifiée et que la date actuelle est dans la StarDate, la réponse de restriction est "Aucune restriction".
+                Si la date est vide, la réponse de restriction est "Restreint" car il n'y a aucun moyen de calculer la date de fin.
+                Si une règle et une date sont précisées, alors la règle est valable (restriction appliquée).</xsd:documentation>
+            <xsd:documentation>La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="Rule" type="RuleIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à la règle de durée d'utilité courante.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="StartDate" type="xsd:date" nillable="true" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Date de départ de calcul de la règle d'utilité courante.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:choice minOccurs="0">
+                <xsd:group ref="PreventInheritanceGroup"/>
+                <xsd:element name="RefNonRuleId" type="RuleIdType" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>L'identifiant de la règle spécifiée pourra être retirée de l'héritage dans ce noeud.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="FinalAction" type="FinalActionStorageCodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Action à mettre en œuvre au terme de la durée de gestion.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <xsd:simpleType name="FinalActionAppraisalCodeType">
+        <xsd:annotation>
+            <xsd:documentation>Code correspondant à l’action à entreprendre au terme de la durée d’utilité administrative.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType">
+            <xsd:enumeration value="Keep"/>
+            <xsd:enumeration value="Destroy"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <xsd:complexType name="AppraisalRuleType">
+        <xsd:annotation>
+            <xsd:documentation>Gestion de la durée d'utilité administrative.</xsd:documentation>
+            <xsd:documentation>Chaque règle a une startDate et un Identifiant de règle de référence pour la durée.
+                Si aucune règle n'est spécifiée et que la date actuelle est dans la StarDate, la réponse de restriction est "Aucune restriction".
+                Si la date est vide, la réponse de restriction est "Restreint" car il n'y a aucun moyen de calculer la date de fin.
+                Si une règle et une date sont précisées, alors la règle est valable (restriction appliquée).</xsd:documentation>
+            <xsd:documentation>La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:sequence minOccurs="0" maxOccurs="unbounded">
+                <xsd:element name="Rule" type="RuleIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à la règle de durée d'utilité administrative.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="StartDate" type="xsd:date" nillable="true" minOccurs="0">
+                    <xsd:annotation>
+                        <xsd:documentation>Date de départ de calcul de durée d'utilité administrative.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:sequence>
+            <xsd:choice minOccurs="0">
+                <xsd:group ref="PreventInheritanceGroup"/>
+                <xsd:element name="RefNonRuleId" type="RuleIdType" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>L'identifiant de la règle spécifiée pourra être retirée de l'héritage dans ce noeud.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="FinalAction" type="FinalActionAppraisalCodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Action à mettre en œuvre au terme de la durée de gestion.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <!-- Gestion des règles de gel des ArchiveUnit -->
+    <xsd:complexType name="HoldRuleType">
+        <xsd:annotation>
+            <xsd:documentation>Gestion de la durée de gel des ArchiveUnits.</xsd:documentation>
+            <xsd:documentation>Chaque règle possède un Identifiant de règle de gel de référence, ainsi qu'un ensemble
+                d'attributs optionnels.</xsd:documentation>
+            <xsd:documentation>La date de fin de gel est calculée à partir d'une date de début de restriction
+                (StardDate) et de la durée de validité de la règle de réference. Elle peut également être explicitement
+                spécifiée (HoldEndDate) si la règle de référence ne spécifie pas de durée déterminée.</xsd:documentation>
+            <xsd:documentation>Si la règle ne possède pas de durée de fin (calculée ou explicite), alors la règle est
+                réputée à durée indéterminée (restriction toujours effective)</xsd:documentation>
+            <xsd:documentation>La liste d'identifiants de règles à appliquer et à ignorer qui doit être appliquée à partir de cet ArchiveUnit.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:group ref="HoldRuleDefGroup" minOccurs="0" maxOccurs="unbounded" />
+            <xsd:choice minOccurs="0">
+                <xsd:group ref="PreventInheritanceGroup"/>
+                <xsd:element name="RefNonRuleId" type="RuleIdType" maxOccurs="unbounded">
+                    <xsd:annotation>
+                        <xsd:documentation>L'identifiant de la règle spécifiée pourra être retirée de l'héritage dans ce noeud.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <xsd:group name="HoldRuleDefGroup">
+        <xsd:sequence>
+            <xsd:element name="Rule" type="RuleIdType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à la règle de gel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="StartDate" type="xsd:date" nillable="true" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de début de gel.</xsd:documentation>
+                    <xsd:documentation>Si la date de début de gel est renseignée, et que la règle de référence
+                        spécifie une durée de validité non nulle, alors la date de fin de gel est automatiquement
+                        calculée par Vitam.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="HoldEndDate" type="xsd:date" nillable="true" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de fin de gel explicite.</xsd:documentation>
+                    <xsd:documentation>Dans le cas où la règle de référence ne spécifie pas de durée de validité, la
+                        règle peut alors spécifier une date de fin de gel explicite (HoldEndDate).</xsd:documentation>
+                    <xsd:documentation>Dans le cas où la règle de référence spécifie une durée de validité, la date
+                        de fin de gel est calculée par Vitam et ne peut être explicitement spécifiée (HoldEndDate prohibé).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="HoldOwner" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Propriétaire de la demande de gel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="HoldReassessingDate" type="xsd:date" nillable="true" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de réévaluation du gel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="HoldReason" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Motif de gel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="PreventRearrangement" type="xsd:boolean" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Blocage de la reclassification de l'ArchiveUnit lorsque la restriction de gel est effective</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+</xsd:schema>

--- a/sedalib/src/main/resources/seda-2.2-ontology.xsd
+++ b/sedalib/src/main/resources/seda-2.2-ontology.xsd
@@ -1,0 +1,1062 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" targetNamespace="fr:gouv:culture:archivesdefrance:seda:v2.2"
+    xmlns:pr="info:lc/xmlns/premis-v2" xmlns="fr:gouv:culture:archivesdefrance:seda:v2.2" elementFormDefault="qualified"
+    attributeFormDefault="unqualified" version="1.0">
+    <xsd:include schemaLocation="seda-2.2-types.xsd"/>
+    
+    <xsd:group name="ObjectGroup">
+        <xsd:annotation>
+            <xsd:documentation>Contient les éléments nécessaires à
+                la description de l'ArchiveUnit et est sensé être la racine du bloc des métadonnées de
+                description.</xsd:documentation>
+            <xsd:documentation>Chaque sous-type ou sous-groupe peut aussi être utilisé pour
+                construire de nouveaux types ou groupes.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:group ref="BaseObjectGroup"/>
+            <xsd:element ref="ObjectGroupExtenstionAbstract" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <xsd:group name="BaseObjectGroup">
+        <xsd:sequence>
+            <xsd:group ref="LevelGroup"/>
+            <xsd:group ref="TitleGroup"/>
+            <xsd:group ref="IdentifierGroup"/>
+            <xsd:group ref="DescriptionGroup"/>
+            <xsd:group ref="CustodialHistoryGroup"/>
+            <xsd:group ref="TypeGroup"/>
+            <xsd:group ref="DocumentTypeGroup"/>
+            <xsd:group ref="LanguageGroup"/>
+            <xsd:group ref="StatusGroup"/>
+            <xsd:group ref="VersionGroup"/>
+            <xsd:group ref="KeywordsGroup"/>
+            <xsd:group ref="CoverageGroup"/>
+            <xsd:group ref="OriginatingAgencyGroup"/>
+            <xsd:group ref="SubmissionAgencyGroup"/>
+            <xsd:group ref="AgentGroup"/>
+            <xsd:group ref="AuthorizedAgentGroup"/>
+            <xsd:group ref="WritingGroup"/>
+            <xsd:group ref="AudienceGroup"/>
+            <xsd:group ref="SourceGroup"/>
+            <xsd:group ref="RelationGroup"/>
+            <xsd:group ref="DateGroup"/>
+            <xsd:group ref="EventGroup"/>
+            <xsd:group ref="SignatureGroup"/>
+            <xsd:group ref="GpsGroup"/>
+            <xsd:group ref="OriginatingSystemIdReplyToGroup"/>
+            <xsd:group ref="TextContentGroup"/>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Level description -->
+    <xsd:group name="LevelGroup">
+        <xsd:sequence>
+            <xsd:element name="DescriptionLevel" type="LevelType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Niveau de description au sens de la norme ISAD (G). Indique si l’ArchiveUnit correspond à un fonds, 
+                        à un sous-fonds, à une classe, à une série organique, à une sous-série organique, à un dossier, à un sous-dossier ou à une pièce.</xsd:documentation>
+                    <xsd:documentation>Référence : seda.DescriptionLevel</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="LevelType">
+        <xsd:annotation>
+            <xsd:documentation>Valeurs de DescriptionLevel.</xsd:documentation>
+            <xsd:documentation>Références : descriptionlevel_code SEDA 1.0</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="Fonds"/>
+            <xsd:enumeration value="Subfonds"/>
+            <xsd:enumeration value="Class"/>
+            <xsd:enumeration value="Collection"/>
+            <xsd:enumeration value="Series"/>
+            <xsd:enumeration value="Subseries"/>
+            <xsd:enumeration value="RecordGrp"/>
+            <xsd:enumeration value="SubGrp"/>
+            <xsd:enumeration value="File"/>
+            <xsd:enumeration value="Item"/>
+            <xsd:enumeration value="OtherLevel"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <!-- Title description -->
+    <xsd:group name="TitleGroup">
+        <xsd:sequence>
+            <xsd:element name="Title" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Intitulé de l'ArchiveUnit.</xsd:documentation>
+                    <xsd:documentation>Références : DC.Title ead.unittitle</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <!-- Identification description -->
+    <xsd:group name="IdentifierGroup">
+        <xsd:sequence>
+            <xsd:element name="FilePlanPosition" type="NonEmptyTokenType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Position de l’ArchiveUnit dans le plan de classement du service producteur.</xsd:documentation>
+                    <xsd:documentation>Références : seda.FilePlanPosition</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="SystemId" type="NonEmptyTokenType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant attribué aux objets. Il est attribué par le SAE et correspond à un identifiant interne.</xsd:documentation>
+                    <xsd:documentation>Références : ARMS</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="OriginatingSystemId" type="NonEmptyTokenType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant système attribué à l’ArchiveUnit par l’application du service producteur.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ArchivalAgencyArchiveUnitIdentifier" type="NonEmptyTokenType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant métier attribué à l'ArchiveUnit par le service d'archives. Peut être comparé à une cote.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="OriginatingAgencyArchiveUnitIdentifier" type="NonEmptyTokenType"
+                minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant métier attribué à l’ArchiveUnit par le service producteur.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="TransferringAgencyArchiveUnitIdentifier" type="NonEmptyTokenType"
+                minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant attribué à l'ArchiveUnit par le service versant.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- General description -->
+    <xsd:group name="DescriptionGroup">
+        <xsd:sequence>
+            <xsd:element name="Description" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Description détaillée de l’ArchiveUnit. Correspond à la présentation du contenu au sens de la norme ISAD(G).</xsd:documentation>
+                    <xsd:documentation>Références : DC:Documentation</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- CustodialHistory type -->
+    <xsd:group name="CustodialHistoryGroup">
+        <xsd:sequence>
+            <xsd:element name="CustodialHistory" type="CustodialHistoryType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Énumère les changements successifs de propriété, de responsabilité et de conservation des ArchiveUnit avant 
+                        leur entrée dans le lieu de conservation. On peut notamment y indiquer comment s'est effectué le passage de l'application 
+                        d'origine au fichier archivable. Correspond à l'historique de la conservation en ISAD(G).</xsd:documentation>
+                    <xsd:documentation>Références : seda.CustodialHistory</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="CustodialHistoryType">
+        <xsd:sequence>
+            <xsd:element name="CustodialHistoryItem" type="CustodialHistoryItemType" minOccurs="1" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Description d'une période ou d'un événement précis dans l'historique.</xsd:documentation>
+                    <xsd:documentation>Références : seda.CustodialHistoryItem</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="CustodialHistoryFile" type="DataObjectRefType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à un fichier de journalisation externe.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="CustodialHistoryItemType">
+        <xsd:complexContent>
+            <xsd:extension base="TextType">
+                <xsd:attribute name="when" type="DateType" use="optional"/>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- OAIS type description -->
+    <xsd:group name="TypeGroup">
+        <xsd:sequence>
+            <xsd:element name="Type" type="TextType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Type d’information au sens de l’OAIS (information de représentation, information de pérennisation, etc.).</xsd:documentation>
+                    <xsd:documentation>Références : seda.DocumentType</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Document type description -->
+    <xsd:group name="DocumentTypeGroup">
+        <xsd:sequence>
+            <xsd:element name="DocumentType" type="TextType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Type de document au sens diplomatique du terme (ex. compte-rendu de réunion, note, correspondance, etc.). Ne pas confondre avec Type.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Language description -->
+    <xsd:group name="LanguageGroup">
+        <xsd:sequence>
+            <xsd:element name="Language" type="xsd:language" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Langue du contenu des objets-données.</xsd:documentation>
+                    <xsd:documentation>Références : seda.Language</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="DescriptionLanguage" type="xsd:language" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Langue utilisée pour les informations de représentation et de pérennisation.</xsd:documentation>
+                    <xsd:documentation>Références : seda.DescriptionLanguage</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Status description -->
+    <xsd:group name="StatusGroup">
+        <xsd:sequence>
+            <xsd:element name="Status" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Etat de l'objet-données (par rapport avec son cycle de vie). Permet par exemple d'indiquer si la signature du fichier a été vérifiée avant le transfert aux archives.</xsd:documentation>
+                    <xsd:documentation>Références : seda.Status</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Version description -->
+    <xsd:group name="VersionGroup">
+        <xsd:sequence>
+            <xsd:element name="Version" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Permet d'indiquer quelle est la version du document.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Keywords description -->
+    <xsd:group name="KeywordsGroup">
+        <xsd:sequence>
+            <xsd:element name="Tag" type="NonEmptyTokenType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Mots-clés ou liste de mots-clés génériques. En ce qui concerne l'indexation, on pourra utiliser Tag ou Keyword en fonction de ce que l'on souhaite décrire.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Keyword" type="KeywordsType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Mots-clef avec contexte inspiré du SEDA 1.0. En ce qui concerne l'indexation, on pourra utiliser Tag ou Keyword en fonction de ce que l'on souhaite décrire.</xsd:documentation>
+                    <xsd:documentation>Références : seda.Keyword</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <!-- Repris du SEDA 1.0 -->
+    <xsd:complexType name="KeywordsType">
+        <xsd:annotation>
+            <xsd:documentation>Mots-clés.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="KeywordContent" type="TextType">
+                <xsd:annotation>
+                    <xsd:documentation>Valeur du mot-clé. A utiliser avec Keyword.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="KeywordReference" type="IdentifierType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant du mot clé dans un référentiel donné. Par exemple, pour un lieu, il pourrait s'agir de son code officiel géographique selon l'INSEE.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="KeywordType" type="KeyType" minOccurs="0" maxOccurs="1">
+                <xsd:annotation>
+                    <xsd:documentation>Type de mot clé.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:ID" use="optional"/>
+    </xsd:complexType>
+    <xsd:complexType name="KeyType">
+        <xsd:simpleContent>
+            <xsd:extension base="CodeKeywordType">
+                <xsd:attribute name="listVersionID" type="xsd:token" use="optional"
+                    default="edition 2009">
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <!-- =============================================================== -->
+    <!-- ===== Code List KeywordType: KeywordType Code           ======= -->
+    <!-- =============================================================== -->
+    <xsd:simpleType name="CodeKeywordType">
+        <xsd:annotation>
+            <xsd:documentation xml:lang="fr">Table des types de mots-clés.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:enumeration value="corpname">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Collectivité.</xsd:documentation>
+                    <xsd:documentation>Références : ead.corpname</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="famname">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Nom de famille.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="geogname">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Nom géographique.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="name">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Nom.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="occupation">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Fonction.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="persname">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Nom de personne.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="subject">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Mot-matière.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="genreform">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Type de document.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+            <xsd:enumeration value="function">
+                <xsd:annotation>
+                    <xsd:documentation xml:lang="fr">Activité.</xsd:documentation>
+                    <xsd:documentation xml:lang="fr">Références : ead.function</xsd:documentation>
+                </xsd:annotation>
+            </xsd:enumeration>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+    <!-- Coverage description -->
+    <xsd:group name="CoverageGroup">
+        <xsd:sequence>
+            <xsd:element name="Coverage" type="CoverageType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Couverture spatiale, temporelle ou juridictionnelle de l’ArchiveUnit</xsd:documentation>
+                    <xsd:documentation>Références : DC.Coverage</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="CoverageType">
+        <xsd:sequence>
+            <xsd:element name="Spatial" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Couverture spatiale ou couverture géographique.</xsd:documentation>
+                    <xsd:documentation>Références: AGKRMS.spatialCoverage</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Temporal" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Couverture temporelle.</xsd:documentation>
+                    <xsd:documentation>Références: AGKRMS.temporalCoverage</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Juridictional" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Juridiction administrative ou ressort administratif.</xsd:documentation>
+                    <xsd:documentation>Références: AGKRMS.juridictionalCoverage</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <!-- OriginatingAgency description -->
+    <xsd:group name="OriginatingAgencyGroup">
+        <xsd:sequence>
+            <xsd:element name="OriginatingAgency" type="OrganizationType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Service producteur. "Personne physique ou morale, publique ou privée, qui a produit, reçu et conservé des archives  dans l'exercice de son activité", Dictionnaire de terminologie archivistique, direction des archives de France, 2002.</xsd:documentation>
+                    <xsd:documentation>Références : seda.OriginatingAgency</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- SubmissionAgency description -->
+    <xsd:group name="SubmissionAgencyGroup">
+        <xsd:sequence>
+            <xsd:element name="SubmissionAgency" type="OrganizationType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Service versant responsable du transfert des données.</xsd:documentation>
+                    <xsd:documentation>Références : seda.SubmissionAgency</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <!-- Proxy description -->
+    <xsd:group name="AuthorizedAgentGroup">
+        <xsd:sequence>
+            <xsd:element name="AuthorizedAgent" type="AgentType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Titulaire des droits de propriété intellectuelle.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Writing description -->
+    <xsd:group name="WritingGroup">
+        <xsd:sequence>
+            <xsd:annotation>
+                <xsd:documentation>Rédacteur de l'objet d'archive.</xsd:documentation>
+            </xsd:annotation>
+            <xsd:element name="Writer" type="AgentType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Rédacteur Rédacteur de l’ArchiveUnit.</xsd:documentation>
+                    <xsd:documentation>Références : interpares.Writer</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Audience description -->
+    <xsd:group name="AudienceGroup">
+        <xsd:sequence>
+            <xsd:annotation>
+                <xsd:documentation>Audience du document.</xsd:documentation>
+            </xsd:annotation>
+            <xsd:group ref="AddresseeGroup"/>
+            <xsd:group ref="RecipientGroup"/>
+            <xsd:group ref="TransmitterGroup"/>
+            <xsd:group ref="SenderGroup"/>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Source description -->
+    <xsd:group name="SourceGroup">
+        <xsd:sequence>
+            <xsd:element name="Source" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>En cas de substitution numérique, permet de faire référence au papier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Relation description -->
+    <xsd:group name="RelationGroup">
+        <xsd:annotation>
+            <xsd:documentation>Les valeurs sont des identifiants au choix : - d'un autre objet données (DataObjectRefIdType ou GroupIdType s'ils sont dans le même transfert, ou identifiant dans le SAE sinon) - d'un autre ArchiveUnit (ArchiveUnitRefIdType s'il est dans le même transfert, ou identifiant dans le SAE sinon).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="RelatedObjectReference" type="RelatedObjectReferenceType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à un objet faisant ou ne faisant pas partie du présent paquet d'information.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="RelatedObjectReferenceType">
+        <xsd:sequence>
+            <xsd:element name="IsVersionOf" type="DataObjectOrArchiveUnitReferenceType"
+                minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Est une version de. Edition, adaptation, traduction. Cette relation permet d'indiquer les modifications dans le contenu.</xsd:documentation>
+                    <xsd:documentation>Références : DC.Relation.isVersionOf</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Replaces" type="DataObjectOrArchiveUnitReferenceType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Remplace. Cette relation permet d'indiquer les objets remplacés par le niveau courant de description.</xsd:documentation>
+                    <xsd:documentation>DC.Relation.replaces</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Requires" type="DataObjectOrArchiveUnitReferenceType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Requiert. Cette relation permet d'indiquer les objets nécessaire à la compréhension du niveau courant de description.</xsd:documentation>
+                    <xsd:documentation>Références : DC.Relation.requires</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="IsPartOf" type="DataObjectOrArchiveUnitReferenceType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Est une partie de. Cette relation permet d'indique qu'un objet est une partie d'un autre.</xsd:documentation>
+                    <xsd:documentation>Références : DC.Relation.isPartOf</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="References" type="DataObjectOrArchiveUnitReferenceType" minOccurs="0"
+                maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Référence. Cette relation permet d'indiquer qu'un objet en référence un autre.</xsd:documentation>
+                    <xsd:documentation>DC.Relation.references</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="DataObjectOrArchiveUnitReferenceType">
+        <xsd:choice>
+            <xsd:element name="ArchiveUnitRefId" type="ArchiveUnitRefIdType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à un ArchiveUnit interne.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="DataObjectReference" type="DataObjectRefType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à un objet-données ou à un groupe d'objets-données interne(s).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="RepositoryArchiveUnitPID" type="NonEmptyTokenType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à un ArchiveUnit déjà conservé dans un système d'archivage.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="RepositoryObjectPID" type="NonEmptyTokenType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à un un objet-données ou à un groupe d'objets-données déjà conservé(s) dans un système d'archivage.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ExternalReference" type="NonEmptyTokenType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence externe.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+    </xsd:complexType>
+    <!-- Date description -->
+    <xsd:group name="DateGroup">
+        <xsd:sequence>
+            <xsd:element name="CreatedDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de création.</xsd:documentation>
+                    <xsd:documentation>Références : ARKMS.DateCreated</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="TransactedDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de la transaction.</xsd:documentation>
+                    <xsd:documentation>Références : ARKMS.DateTransacted</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="AcquiredDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de numérisation.</xsd:documentation>
+                    <xsd:documentation>Références : ARKMS.DateAcquired</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="SentDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date d'envoi.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ReceivedDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de réception.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="RegisteredDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date d'enregistrement.</xsd:documentation>
+                    <xsd:documentation>Références : ARMS.DateDeclared</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="StartDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date d'ouverture / date de début.</xsd:documentation>
+                    <xsd:documentation>Références : AGKRMS.StartDate</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="EndDate" type="DateType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de fermeture / Date de fin.</xsd:documentation>
+                    <xsd:documentation>Références : AGKRMS.EndDate</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="DateLitteral" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Champ date en texte libre.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="DateType">
+        <xsd:union memberTypes="xsd:date xsd:dateTime xsd:gYear xsd:gYearMonth xsd:gMonth xsd:gMonthDay xsd:gDay"/>
+    </xsd:simpleType>
+    <!-- Event description -->
+    <xsd:group name="EventGroup">
+        <xsd:sequence>
+            <xsd:element name="Event" type="EventType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Informations décrivant un événement survenu au cours d’une procédure (ex. publication d’un marché, notification d’un marché, recueil d’un avis administratif, etc.).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="EventType">
+        <xsd:sequence>
+            <xsd:element name="EventIdentifier" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant de l'événement.</xsd:documentation>
+                    <xsd:documentation>Références : premis.eventIdentifier</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="EventTypeCode" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Code du type d'événement.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="EventType" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Type d'événement.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="EventDateTime" type="DateType">
+                <xsd:annotation>
+                    <xsd:documentation>Date et heure de l'événement.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="EventDetail" type="TextType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Détail sur l'événement.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Outcome" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Résultat du traitement.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="OutcomeDetail" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Détail sur le résultat du traitement.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="OutcomeDetailMessage" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Message détaillé sur le résultat du traitement.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="EventDetailData" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Message technique détaillant l'erreur.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="LinkingAgentIdentifier" type="LinkingAgentIdentifierType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Permet de renseigner des agents répertoriés dans des évènements.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="EventAbstract" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Permet d'étendre de nouveaux types d'évenéments.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="LinkingAgentIdentifierType">
+        <xsd:sequence>
+            <xsd:element name="LinkingAgentIdentifierType" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant d'un agent répertorié dans des évènements.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="LinkingAgentIdentifierValue" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Mention d'un agent répertorié dans des évènements.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="LinkingAgentRole"  type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Fonction d'un agent répertorié dans des évènements.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <!-- Signature description -->
+    <xsd:group name="SignatureGroup">
+        <xsd:sequence>
+            <xsd:element name="Signature" type="SignatureType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Contient toutes les informations relatives à la signature.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="SignatureType">
+        <xsd:sequence>
+            <xsd:element name="Signer" type="SignerType" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Signataire(s) de la transaction ou de l'objet.</xsd:documentation>
+                    <xsd:documentation>Références : premis.signer</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Validator" type="ValidatorType">
+                <xsd:annotation>
+                    <xsd:documentation>Validateur de la signature.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Masterdata" type="CodeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Référentiel des personnes et des organisations au moment de la vérification de la signature et de sa validation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="ReferencedObject" type="ReferencedObjectType">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à l'objet signé.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:complexType name="SignerType">
+        <xsd:group ref="SignerGroup"/>
+    </xsd:complexType>
+    <xsd:complexType name="ValidatorType">
+        <xsd:group ref="ValidatorGroup"/>
+    </xsd:complexType>
+    <xsd:complexType name="ReferencedObjectType">
+        <xsd:annotation>
+            <xsd:documentation>Contient la référence à l'objet signé (et son empreinte jusqu'à la fin de la phase de versement dans le SAE).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="SignedObjectId" type="DataObjectRefIdType">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant de l'objet-données signé.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="SignedObjectDigest" type="MessageDigestBinaryObjectType">
+                <xsd:annotation>
+                    <xsd:documentation>Empreinte obligatoire jusqu'au processus de versement pour assurer la portabilité de la valeur probante. Le SAE peut ne pas la conserver si l'on considère que l'identifiant de l'objet correspondant suffit. Ce procédé permet de résister au temps lorsque les informations binaires du paquet seront converties au gré des opérations de préservation de la lisibilité des formats. Au cours de ces opérations, l'identifiant ne changera pas, contrairement au format dufichier et donc à son empreinte.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:group name="SignerGroup">
+        <xsd:sequence>
+            <xsd:group ref="PersonOrEntityGroup"/>
+            <xsd:element name="SigningTime" type="xsd:dateTime">
+                <xsd:annotation>
+                    <xsd:documentation>Date de signature.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:group ref="BusinessGroup"/>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="ValidatorGroup">
+        <xsd:sequence>
+            <xsd:group ref="PersonOrEntityGroup"/>
+            <xsd:element name="ValidationTime" type="xsd:dateTime">
+                <xsd:annotation>
+                    <xsd:documentation>Date de la validation de la signature.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:group ref="BusinessGroup"/>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Addressee description -->
+    <xsd:group name="AddresseeGroup">
+        <xsd:sequence>
+            <xsd:element name="Addressee" minOccurs="0" maxOccurs="unbounded" type="AgentType">
+                <xsd:annotation>
+                    <xsd:documentation>Destinataire pour action. Utilisé pour indiquer le nom du destinatire par exemple dans un courrier électronique.</xsd:documentation>
+                    <xsd:documentation>Références : ARMS.Addressee, Interpares.Addressee</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <!-- Recipient description -->
+    <xsd:group name="RecipientGroup">
+        <xsd:sequence>
+            <xsd:element name="Recipient" minOccurs="0" maxOccurs="unbounded" type="AgentType">
+                <xsd:annotation>
+                    <xsd:documentation>Destinataire pour information. Utilisé pour indiquer le nom du destinatire en copie, pour information, par exemple dans un courrier électronique.</xsd:documentation>
+                    <xsd:documentation>Références : Interpares.Recipient</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <!-- Transmitter description -->
+    <xsd:group name="TransmitterGroup">
+        <xsd:sequence>
+            <xsd:element name="Transmitter" type="AgentType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Emetteur du message.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <!-- Sender description -->
+    <xsd:group name="SenderGroup">
+        <xsd:sequence>
+            <xsd:element name="Sender" type="AgentType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Expéditeur du message.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+   
+    <!-- Pour ajouter des agents génériques -->
+    <xsd:group name="AgentGroup">
+        <xsd:sequence>
+            <xsd:element name="Agent" type="AgentType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Agent générique.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <!-- Agent description -->
+    <xsd:complexType name="AgentType">
+        <xsd:annotation>
+            <xsd:documentation>Informations décrivant une personne physique ou morale.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:group ref="PersonOrEntityGroup"/>
+            <xsd:group ref="BusinessGroup"/>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <!-- Person or Entity description -->
+    <xsd:group name="PersonOrEntityGroup">
+        <xsd:sequence>
+            <xsd:choice>
+                <xsd:sequence>
+                    <xsd:element name="FirstName" type="xsd:string" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Prénom d'une personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="BirthName" type="xsd:string" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Nom de naissance d'une personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="FullName" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Nom complet d'une personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="GivenName" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Nom d'usage d'une personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Gender" type="NonEmptyTokenType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Sexe de la personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="BirthDate" type="xsd:date" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Date de naissance de la personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="BirthPlace" type="BirthOrDeathPlaceType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Lieu de naissance de la personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="DeathDate" type="xsd:date" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Date de décès d'une personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="DeathPlace" type="BirthOrDeathPlaceType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Lieu de décès d'une personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Nationality" minOccurs="0" maxOccurs="unbounded" type="NonEmptyTokenType">
+                        <xsd:annotation>
+                            <xsd:documentation>Nationalité d'une personne.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+                <xsd:sequence>
+                    <xsd:element name="Corpname" type="xsd:string">
+                        <xsd:annotation>
+                            <xsd:documentation>Nom d'une entité.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:choice>
+            <xsd:element name="Identifier" type="NonEmptyTokenType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant de la personne (par exemple, le numéro matricule) ou de l'entité.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="BirthOrDeathPlaceType">
+        <xsd:group ref="LocationGroup"/>
+    </xsd:complexType>
+    <!-- Business description -->
+    <xsd:group name="BusinessGroup">
+        <xsd:annotation>
+            <xsd:documentation>Références : AGKRMS.Business</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="Function" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Fonction.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Activity" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Activité.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Position" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Intitulé du poste de travail occupé par la personne.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Role" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Droits avec lesquels un utilisateur a réalisé une opération, notamment dans une application.</xsd:documentation>
+                    <xsd:documentation>Références : moreq.role</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Mandate" type="TextType" minOccurs="0" maxOccurs="unbounded">
+                <xsd:annotation>
+                    <xsd:documentation>Définit la propriété intellectuelle et artistique.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <!-- Location description -->
+    <xsd:group name="LocationGroup">
+        <xsd:annotation>
+            <xsd:documentation>Localisation.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:all>
+            <xsd:element name="Geogname" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Nom géographique.</xsd:documentation>
+                    <xsd:documentation>Références : ead.geogname</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Address" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Adresse.</xsd:documentation>
+                    <xsd:documentation>Références : ead.address</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="PostalCode" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Code postal.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="City" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Ville.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Region" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Région.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Country" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>En plus des balises Tag et Keyword, il est possible d'indexer les objets avec des éléments pré-définis : Pays.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:all>
+    </xsd:group>
+    <!-- GPS Description: shared with Descriptive and Technical -->
+    <xsd:group name="GpsGroup">
+        <xsd:sequence>
+            <xsd:element name="Gps" type="GpsType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Coordonnées gps complétées ou vérifiées par un utilisateur. Fait référence à des coordonnées traitées par un utilisateur et non à des coordonnées captées.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="GpsType">
+        <xsd:sequence>
+            <xsd:element name="GpsVersionID" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant de la version du GPS.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="GpsAltitude" type="xsd:integer" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Indique l'altitude basée sur la référence dans GPSAltitudeRef. L'altitude est exprimée en mètres.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="GpsAltitudeRef" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Indique l'altitude utilisée comme altitude de référence.</xsd:documentation>
+                    <xsd:documentation>Si l'altitude est au dessus du niveau de la mer, la valeur 0 est normalement donnée.</xsd:documentation>
+                    <xsd:documentation>Si l'altitude est au-dessous du niveau de la mer, la veleur 1 est normalement donnée.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="GpsLatitude" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>La latitude peut être exprimée de deux manières différentes : 1)degrés, décimaux ou 2)degrés, minutes et secondes.</xsd:documentation>
+                    <xsd:documentation>1)Si la latitude est exprimée en degrés, décimaux, le format type est dd, dd. Par ex: "45.3130339".</xsd:documentation>
+                    <xsd:documentation>2)Si la latitude est exprimée en degrés, minutes et secondes, le format type est dd, mm, ss. Par ex: "45 18 46.922".</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="GpsLatitudeRef" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Indique si la latitude est nord ou sud. La valeur 'N' indique la latitude nord, et 'S' indique la latitude sud.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="GpsLongitude" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>La longitude peut être exprimée de deux manières différentes : 1)degrés, décimaux ou 2)degrés, minutes et secondes.</xsd:documentation>
+                    <xsd:documentation>1)Si la longitude est exprimée en degrés, décimaux, le format type est dd, dd. Par ex: "5.392285833333334".</xsd:documentation>
+                    <xsd:documentation>2)Si la longitude est exprimée en degrés, minutes et secondes, le format type est dd, mm, ss. Par ex: "5 23 32.229".</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="GpsLongitudeRef" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Indique si la longitude est est ou ouest. La valeur 'E' indique la longitude est, et 'W' indique la longitude Ouest.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="GpsDateStamp" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Heure et Date de la position GPS.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    <xsd:group name="OriginatingSystemIdReplyToGroup">
+        <xsd:sequence>
+            <xsd:element name="OriginatingSystemIdReplyTo" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Référence du message auquel on répond.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:group name="TextContentGroup">
+        <xsd:sequence>
+            <xsd:element name="TextContent" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Contenu du message électronique.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+</xsd:schema>

--- a/sedalib/src/main/resources/seda-2.2-technical.xsd
+++ b/sedalib/src/main/resources/seda-2.2-technical.xsd
@@ -1,0 +1,530 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="fr:gouv:culture:archivesdefrance:seda:v2.2"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink"
+    xmlns="fr:gouv:culture:archivesdefrance:seda:v2.2" elementFormDefault="qualified"
+    attributeFormDefault="unqualified" version="1.0">
+    <xsd:include schemaLocation="seda-2.2-types.xsd"/>
+    <xsd:include schemaLocation="seda-2.2-ontology.xsd"/>
+    <!--
+                *****************************
+                ***   Code List
+                *****************************
+ 
+        -->
+    <xsd:group name="TechnicalCodeListsGroup">
+        <xsd:annotation>
+            <xsd:documentation>Liste de codes à utiliser dans les métadonnées
+                techniques.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:group ref="DigestAlgorithmCodeListGroup"/>
+            <xsd:group ref="MimeTypeCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="EncodingCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="FileFormatCodeListGroup"/>
+            <xsd:group ref="CompressionAlgorithmCodeListGroup" minOccurs="0"/>
+            <xsd:group ref="DataObjectVersionCodeListGroup" minOccurs="0"/>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Identification of format code -->
+    <xsd:simpleType name="MimeTypeType">
+        <xsd:annotation>
+            <xsd:documentation>Code de type Mime.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType"/>
+    </xsd:simpleType>
+    <xsd:group name="MimeTypeCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="MimeTypeCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version de la liste de code du type Mime.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="EncodingType">
+        <xsd:annotation>
+            <xsd:documentation>Encodage du fichier.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType"/>
+    </xsd:simpleType>
+    <xsd:group name="EncodingCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="EncodingCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version de la liste de code d'encodage du
+                        fichier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="FileFormatType">
+        <xsd:annotation>
+            <xsd:documentation>Identification du format de fichier.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType"/>
+    </xsd:simpleType>
+    <xsd:group name="FileFormatCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="FileFormatCodeListVersion" type="CodeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Version de la liste de code d'identification du format.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="CompressionAlgorithmType">
+        <xsd:annotation>
+            <xsd:documentation>Algorithme de compression utilisée.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType"/>
+    </xsd:simpleType>
+    <xsd:group name="CompressionAlgorithmCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="CompressionAlgorithmCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Version de la liste de code de l'algorithme de compression.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- Identification d'une version pour un même objet intellectuel  -->
+    <xsd:group name="DataObjectVersionCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="DataObjectVersionCodeListVersion" type="CodeType">
+                <xsd:annotation>
+                    <xsd:documentation>Liste de codes correspondant aux diverses versions d'un objet-données au sein d’un groupe d'objets-données (ex. original papier, conservation, diffusion, vignette, txt).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="VersionIdType">
+        <xsd:annotation>
+            <xsd:documentation>Identifiant utilisé pour référencer les versions (conservation, diffusion, thumbnail/vignette, raw/brut, txt, ...).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType"/>
+    </xsd:simpleType>
+
+    <!-- Paquet d'Objets-données -->
+    <xsd:group name="DataObjectVersionGroup">
+        <xsd:annotation>
+            <xsd:documentation>Groupe d’objets-données (numériques ou physiques), correspondant aux
+                différentes versions d’un même objet intellectuellement unique. Chaque version peut
+                être par exemple : original papier, version de conservation, version de diffusion,
+                version vignette, version texte ascii… Lorsqu'un objet-donnée fait partie d'un
+                groupe, le référencement dans les ArchiveUnit ne peut se faire que via ce groupe
+                (DataObjectGroupId).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:choice>
+                <xsd:element name="DataObjectGroupReferenceId" type="GroupRefIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à un Identifiant du groupe d'objets-données DataObjectVersionGroup.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="DataObjectGroupId" type="GroupIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Identifiant du groupe d'objets-données DataObjectVersionGroup (première et unique définition).</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:complexType name="MinimalDataObjectType" abstract="true">
+        <xsd:sequence>
+            <xsd:element name="DataObjectProfile" type="IdentifierType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Référence à une partie d'un profil d’archivage applicable à un objet technique en particulier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="DataObjectSystemId" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant attribué aux objets de données. Il est attribué par le SAE et correspond à un identifiant interne.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="DataObjectGroupSystemId" type="NonEmptyTokenType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant attribué aux groupes d'objets de données. Il est attribué par le SAE et correspond à un identifiant interne.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Relationship" minOccurs="0" maxOccurs="unbounded"
+                type="RelationshipType">
+                <xsd:annotation>
+                    <xsd:documentation>Permet de spécifier un lien technique entre un objet-données et une signature.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:group ref="DataObjectVersionGroup" minOccurs="0"/>
+            <xsd:element name="DataObjectVersion" type="VersionIdType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Version d’un objet-données (par exemple : original papier, conservation, diffusion, vignette, txt, …).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="DataObjectIdType" use="required">
+            <xsd:annotation>
+                <xsd:documentation>Identifiant de l'objet-données associé.</xsd:documentation>
+            </xsd:annotation>
+        </xsd:attribute>
+    </xsd:complexType>
+    
+    <!-- Données liées -->
+    <xsd:complexType name="RelationshipType">
+        <xsd:attribute name="target" type="xsd:IDREF" use="required"/>
+        <xsd:attribute name="type" type="NonEmptyTokenType" use="required"/>
+    </xsd:complexType>
+    
+    <xsd:group name="MinimalBinaryDataObjectGroup">
+        <xsd:sequence>
+            <xsd:choice minOccurs="0" maxOccurs="1">
+                <xsd:element name="Attachment" type="BinaryObjectType">
+                    <xsd:annotation>
+                        <xsd:documentation>Objet-données (contenu binaire ou fichier joint).</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="Uri" type="xsd:anyURI">
+                    <xsd:annotation>
+                        <xsd:documentation>L'URI spécifie où se trouve l'objet-données numérique. Peut correspondre à un chemin relatif.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+            <xsd:element name="MessageDigest" type="MessageDigestBinaryObjectType"> 
+                <xsd:annotation>
+                    <xsd:documentation>Empreinte de l'objet-données.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <!-- Contenu de données binaire -->
+    <xsd:complexType name="BinaryObjectType"> 
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:base64Binary">
+                <xsd:attribute name="filename" type="xsd:string" use="optional"/>
+                <xsd:attribute name="uri" type="xsd:anyURI" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType> 
+
+    <!-- Objet de donnees numérique -->
+    <xsd:complexType name="BinaryDataObjectType">
+        <xsd:annotation>
+            <xsd:documentation>Objet-données numérique.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="MinimalDataObjectType">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées techniques minimales : URI, Digest, Poids.</xsd:documentation>
+                </xsd:annotation>
+                <xsd:sequence>
+                    <xsd:group ref="MinimalBinaryDataObjectGroup" minOccurs="0"/>
+                    <xsd:element name="Size" type="SizeInBytesType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Permet de spécifier la taille de l'objet-données en octet.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Compressed" type="CompressedType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Indique si l’objet-données est compressé et doit être décompressé.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:group ref="BinaryTechnicalDescriptionGroup">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnées techniques pour les objets-données numériques.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:group>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    
+    
+    
+    <xsd:complexType name="CompressedType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute name="algorithm" type="CompressionAlgorithmType" use="required"/>
+                <xsd:attribute name="uncompressedSize" type="SizeInBytesType" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+
+    <xsd:group name="BinaryTechnicalDescriptionGroup">
+        <xsd:annotation>
+            <xsd:documentation>Métadonnées techniques pour les objets-données numériques.</xsd:documentation>
+            <xsd:documentation>Inspiré du schéma FITS.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="FormatIdentification" type="FormatIdentificationType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Identification du format de l'objet-données.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="FileInfo" type="FileInfoType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Propriétés techniques génériques du fichier (nom d’origine, logiciel de création, système d’exploitation de création).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Metadata" type="CoreMetadataType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Propriétés techniques spécifiques du fichier en fonction de sa nature technique (texte, document, image, audio, vidéo, etc.).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="OtherMetadata" type="DescriptiveTechnicalMetadataType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Autres métadonnées techniques si celles définies précédemment ne suffisent pas.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+
+    <!-- FormatIdentification elements -->
+    <xsd:complexType name="FormatIdentificationType">
+        <xsd:sequence>
+            <xsd:element name="FormatLitteral" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Forme littérale du nom du format.</xsd:documentation>
+                    <xsd:documentation>Exemple : Microsoft Word Document.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="MimeType" type="MimeTypeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Type Mime associé, potentiellement stable mais pas assez précis.</xsd:documentation>
+                    <xsd:documentation>Exemple : application/msword</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="FormatId" type="FileFormatType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Type spécifique du format tel que défini dans FormatIdCodeList.</xsd:documentation>
+                    <xsd:documentation>Exemple : (Pronom)fmt/40</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Encoding" type="EncodingType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Encodage du fichier tel que défini dans EncodingIdCodeList.</xsd:documentation>
+                    <xsd:documentation>Exemple : Utf-8</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- File info elements -->
+    <xsd:complexType name="FileInfoType">
+        <xsd:annotation>
+            <xsd:documentation>Informations sur le fichier lui-même (d'un point de vue technique).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="Filename" type="xsd:string">
+                <xsd:annotation>
+                    <xsd:documentation>Nom du fichier d'origine.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="CreatingApplicationName" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Nom de l'application utilisée pour créer le fichier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="CreatingApplicationVersion" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Version de l'application utilisée pour créer le fichier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="DateCreatedByApplication" type="xsd:dateTime" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de création du fichier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="CreatingOs" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Système d’exploitation utilisé pour créer le fichier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="CreatingOsVersion" type="xsd:string" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Version du système d'exploitation utilisé pour créer le fichier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="LastModified" type="xsd:dateTime" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Date de la dernière modification du fichier.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+
+    <!-- Objet de donnees physique -->
+    <xsd:group name="PhysicalTechnicalDescriptionGroup">
+        <xsd:annotation>
+            <xsd:documentation>Objet-données physique.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:element name="PhysicalDimensions" type="DimensionsType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Dimensions d'un objet-données physique.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="OtherDimensionsAbstract" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+    </xsd:group>
+    
+    <!-- Objet de donnees physique pour les messages Request -->
+    <xsd:complexType name="PhysicalDataObjectType">
+        <xsd:complexContent>
+            <xsd:extension base="MinimalDataObjectType">
+                <xsd:sequence>
+                    <xsd:element name="PhysicalId" type="IdentifierType" minOccurs="0">
+                        <xsd:annotation>
+                            <xsd:documentation>Identifiant physique d’un objet-données physique, externe à celui-ci (ex. code-barres).</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:group ref="PhysicalTechnicalDescriptionGroup"/>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- Metadata types: inspired from various Library of Congress schema -->
+    <xsd:complexType name="CoreMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Métadonnées de base par type d'objet-données.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:choice>
+            <xsd:element name="Text" type="TextTechnicalMetadataType">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées pour un objet-données de type textuel.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Document" type="DocumentTechnicalMetadataType">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées pour un objet-données de type document.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Image" type="ImageTechnicalMetadataType">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées pour un objet-données de type image.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Audio" type="AudioTechnicalMetadataType">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées pour un objet-données de type audio.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="Video" type="VideoTechnicalMetadataType">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées pour un objet-données de type vidéo.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element ref="OtherCoreTechnicalMetadataAbstract">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées pour un objet-données d’un autre type (base de données, 3D, programmes, formats propriétaires, etc.).</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:choice>
+    </xsd:complexType>
+
+    <!-- Physical description: inspired from AudioMD of Library of Congress and UNECE_MeasurementUnitCommonCode -->
+    <xsd:complexType name="DimensionsType">
+        <xsd:annotation>
+            <xsd:documentation>Permet d'exprimer les mesures de dimensions basiques.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="BaseDimensionsType">
+                <xsd:sequence>
+                    <xsd:element name="Width" type="MeasurementType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : largeur.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Height" type="MeasurementType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : hauteur.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Depth" type="MeasurementType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : profondeur.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Shape" type="xsd:string" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : forme.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Diameter" type="MeasurementType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : diamètre.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Length" type="MeasurementType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : longueur.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Thickness" type="MeasurementType" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : épaisseur.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="Weight" type="MeasurementWeightType" minOccurs="0"
+                        maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : poids.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                    <xsd:element name="NumberOfPage" type="xsd:int" minOccurs="0" maxOccurs="1">
+                        <xsd:annotation>
+                            <xsd:documentation>Métadonnée de dimension physique : nombre de pages.</xsd:documentation>
+                        </xsd:annotation>
+                    </xsd:element>
+                </xsd:sequence>
+            </xsd:extension>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="BaseDimensionsType" abstract="true"/>
+    <xsd:complexType name="MeasurementType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:decimal">
+                <xsd:attribute name="unit" type="MeasurementUnitsType" use="required">
+                    <xsd:annotation>
+                        <xsd:documentation>Références : Voir UNECE_MeasurementUnitCommonCode_8.xsd</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:attribute>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:simpleType name="MeasurementUnitsType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="micrometre"/>
+            <xsd:enumeration value="4H"/>
+            <xsd:enumeration value="millimetre"/>
+            <xsd:enumeration value="MMT"/>
+            <xsd:enumeration value="centimetre"/>
+            <xsd:enumeration value="CMT"/>
+            <xsd:enumeration value="metre"/>
+            <xsd:enumeration value="inch"/>
+            <xsd:enumeration value="INH"/>
+            <xsd:enumeration value="foot"/>
+            <xsd:enumeration value="FOT"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <xsd:complexType name="MeasurementWeightType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:decimal">
+                <xsd:attribute name="unit" type="MeasurementWeightUnitsType" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    <xsd:simpleType name="MeasurementWeightUnitsType">
+        <xsd:restriction base="xsd:string">
+            <xsd:enumeration value="microgram"/>
+            <xsd:enumeration value="MC"/>
+            <xsd:enumeration value="milligram"/>
+            <xsd:enumeration value="MGM"/>
+            <xsd:enumeration value="gram"/>
+            <xsd:enumeration value="GRM"/>
+            <xsd:enumeration value="kilogram"/>
+            <xsd:enumeration value="KGM"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+
+</xsd:schema>

--- a/sedalib/src/main/resources/seda-2.2-types.xsd
+++ b/sedalib/src/main/resources/seda-2.2-types.xsd
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema
+        targetNamespace="fr:gouv:culture:archivesdefrance:seda:v2.2"
+        xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xmlns="fr:gouv:culture:archivesdefrance:seda:v2.2"
+        elementFormDefault="qualified"
+        attributeFormDefault="unqualified"
+        version="1.0">
+    <xsd:include schemaLocation="seda-2.2-ontology.xsd"/>
+    
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" schemaLocation="http://www.w3.org/2001/xml.xsd"/>
+    <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.w3.org/1999/xlink.xsd"/>
+
+    <!--
+                *****************************
+                ***   Types de base
+                *****************************
+        -->
+    <!-- Code -->
+    <xsd:complexType name="CodeType">
+        <xsd:simpleContent>
+            <xsd:extension base="NonEmptyTokenType">
+                <xsd:attribute name="listID" type="xsd:token" use="optional"/>
+                <xsd:attribute name="listAgencyID" type="xsd:token" use="optional"/>
+                <xsd:attribute name="listAgencyName" type="xsd:string" use="optional"/>
+                <xsd:attribute name="listName" type="xsd:string" use="optional"/>
+                <xsd:attribute name="listVersionID" type="xsd:token" use="optional"/>
+                <xsd:attribute name="name" type="xsd:string" use="optional"/>
+                <xsd:attribute name="languageID" type="xsd:language" use="optional"/>
+                <xsd:attribute name="listURI" type="xsd:anyURI" use="optional"/>
+                <xsd:attribute name="listSchemeURI" type="xsd:anyURI" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    
+    <!-- Texte -->
+    <xsd:complexType name="TextType">
+        <xsd:simpleContent>
+            <xsd:extension base="xsd:string">
+                <xsd:attribute ref="xml:lang" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    
+    <!-- Identifiant -->
+    <xsd:complexType name="IdentifierType">
+        <xsd:simpleContent>
+            <xsd:extension base="NonEmptyTokenType">
+                <xsd:attribute name="schemeID" type="xsd:token" use="optional"/>
+                <xsd:attribute name="schemeName" type="xsd:string" use="optional"/>
+                <xsd:attribute name="schemeAgencyID" type="xsd:token" use="optional"/>
+                <xsd:attribute name="schemeAgencyName" type="xsd:string" use="optional"/>
+                <xsd:attribute name="schemeVersionID" type="xsd:token" use="optional"/>
+                <xsd:attribute name="schemeDataURI" type="xsd:anyURI" use="optional"/>
+                <xsd:attribute name="schemeURI" type="xsd:anyURI" use="optional"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    
+    <!-- Type à spécifier -->
+    <xsd:attributeGroup name="OpenTypeAttributeGroup">
+        <xsd:attribute ref="xml:id" use="optional"/>
+        <xsd:attribute ref="xlink:href" use="optional"/>
+    </xsd:attributeGroup>
+    <xsd:complexType name="OpenType" abstract="true">
+        <xsd:sequence>
+            <xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+        </xsd:sequence>
+        <xsd:attributeGroup ref="OpenTypeAttributeGroup"/>
+    </xsd:complexType> 
+
+    <xsd:simpleType name="NonEmptyTokenType">
+        <xsd:annotation>
+            <xsd:documentation>Elément ne pouvant être vide.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:token">
+            <xsd:minLength value="1"/>
+        </xsd:restriction>
+    </xsd:simpleType>
+    <!-- ID -->
+    <xsd:simpleType name="DataObjectIdType">
+        <xsd:annotation>
+            <xsd:documentation>Identifiant utilisé pour les objets-données.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:ID"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="DataObjectRefIdType">
+        <xsd:annotation>
+            <xsd:documentation>Identifiant servant aux relations des objets-données.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:IDREF"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="GroupIdType">
+        <xsd:annotation>
+            <xsd:documentation>Identifiant utilisé pour les groupes d'objets-données.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:union>
+            <xsd:simpleType>
+                <xsd:restriction base="xsd:ID"/>
+            </xsd:simpleType>
+        </xsd:union>
+    </xsd:simpleType>
+    <xsd:simpleType name="GroupRefIdType">
+        <xsd:annotation>
+            <xsd:documentation>Identifiant utilisé pour référencer les groupes d'objets-données.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:IDREF"/>
+    </xsd:simpleType>
+    <xsd:complexType name="DataObjectRefType">
+        <xsd:annotation>
+            <xsd:documentation>Référence à un objet-données ou à un groupe d'objets-données.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:sequence>
+            <xsd:choice>
+                <xsd:element name="DataObjectReferenceId" type="DataObjectRefIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à un objet-données listé dans les métadonnées de transport.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+                <xsd:element name="DataObjectGroupReferenceId" type="GroupRefIdType">
+                    <xsd:annotation>
+                        <xsd:documentation>Référence à un groupe d'objets-données listé dans les métadonnées de transport.</xsd:documentation>
+                    </xsd:annotation>
+                </xsd:element>
+            </xsd:choice>
+        </xsd:sequence>
+        <xsd:attribute name="id" type="xsd:ID" use="optional"/>
+    </xsd:complexType>
+    
+    <!-- ID of an ArchiveUnit -->
+    <xsd:simpleType name="ArchiveUnitIdType">
+        <xsd:annotation>
+            <xsd:documentation>Identifiant utilisé pour les unités d'archives.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:ID"/>
+    </xsd:simpleType>
+    <xsd:simpleType name="ArchiveUnitRefIdType">
+        <xsd:annotation>
+            <xsd:documentation>Référence aux identifiants utilisés pour les unités d'archives.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:IDREF"/>
+    </xsd:simpleType>
+    
+    <xsd:simpleType name="SizeInBytesType">
+        <xsd:annotation>
+            <xsd:documentation>Poids des objets-données binaires en bytes.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="xsd:positiveInteger"/>
+    </xsd:simpleType>
+
+    <!-- Binary encoding -->
+    <xsd:simpleType name="BinaryType">
+        <xsd:annotation>
+            <xsd:documentation>Représentation binaire : utilisation possible de base64 ou d'hexadécimal.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:union memberTypes="xsd:base64Binary xsd:hexBinary"/>
+    </xsd:simpleType>
+    
+    <!-- Digest -->
+    <xsd:group name="DigestAlgorithmCodeListGroup">
+        <xsd:sequence>
+            <xsd:element name="MessageDigestAlgorithmCodeListVersion" type="CodeType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Liste de l'algorithme de hachage utilisé dans le message.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:group>
+    <xsd:simpleType name="DigestAlgorithmCodeType">
+        <xsd:annotation>
+            <xsd:documentation>Algorithme de hachage spécifié dans DigestAlgorithmCodeList.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:restriction base="NonEmptyTokenType"/>
+    </xsd:simpleType>
+    <xsd:complexType name="MessageDigestBinaryObjectType">
+        <xsd:simpleContent>
+            <xsd:extension base="BinaryType">
+                <xsd:attribute name="algorithm" type="DigestAlgorithmCodeType" use="required"/>
+            </xsd:extension>
+        </xsd:simpleContent>
+    </xsd:complexType>
+    
+    <!--
+                *****************************
+                ***   Types métier
+                *****************************
+ 
+        -->
+    
+    <!-- Organisation -->
+    <xsd:complexType name="OrganizationType">
+        <xsd:sequence>
+            <xsd:element name="Identifier" type="IdentifierType">
+                <xsd:annotation>
+                    <xsd:documentation>Identifiant de l'organisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="OrganizationDescriptiveMetadata" type="OrganizationDescriptiveMetadataType" minOccurs="0">
+                <xsd:annotation>
+                    <xsd:documentation>Métadonnées de description de l'organisation.</xsd:documentation>
+                </xsd:annotation>
+            </xsd:element>
+        </xsd:sequence>
+    </xsd:complexType>
+    
+    <!--
+                ***************************** 
+                ***   Objets à redéfinir
+                *****************************
+                La redéfinition permet de fixer le nom de la balise tout en permettant la définition du type ultérieurement
+        -->
+    
+    <!-- Métadonnées descriptives pour une organisation -->
+    <xsd:complexType name="OrganizationDescriptiveMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées de description des organisations.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+        
+    <!-- Signature in Main message block -->
+    <xsd:complexType name="SignatureMessageType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées dsur la signature.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+
+    <!-- In CoreMetadataType from seda-2.2-technical.xsd: Technical Metadata Content -->
+    <xsd:complexType name="TextTechnicalMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées techniques de base pour les objets-données de type texte(XML, JSON, CSV, ...).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="DocumentTechnicalMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées techniques de base pour les objets-données de type document (Word, PDF, XLS, LibreOffice, ...).</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="ImageTechnicalMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées techniques de base pour les objets-données de type image.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="AudioTechnicalMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées techniques de base pour les objets-données de type audio.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="VideoTechnicalMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées techniques de base pour les objets-données de type video.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+    <xsd:complexType name="DescriptiveTechnicalMetadataType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées techniques et/ou descriptives définies dans un schéma par un service producteur ou versant mais n'étant pas présentes dans les métadonnées de base.</xsd:documentation>
+        </xsd:annotation>
+        <xsd:complexContent>
+            <xsd:extension base="OpenType"/>
+        </xsd:complexContent>
+    </xsd:complexType>
+    
+    <!--
+                ******************************************* 
+                ***   Objets à spécifier par substitution
+                *******************************************
+                La substitution permet de ne pas fixer le nom de la balise, d'en autoriser plusieurs et de laisser l'implémentation choisir en fonction de ses besoins.
+        -->
+    <!-- In ObjectGroup from seda-2-0-ontology.xsd: Extra Descriptive Metadata Content -->
+    <xsd:element name="ObjectGroupExtenstionAbstract" abstract="true">
+        <xsd:annotation>
+            <xsd:documentation>Permet d'étendre ObjectGroup avec d'autres métadonnées descriptives.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    
+    <!-- In PhysicalTechnicalDescriptionGroup from seda-2.2-technical.xsd: extra dimension techncal description for PhysicalDataObject -->
+    <xsd:element name="OtherDimensionsAbstract" abstract="true">
+        <xsd:annotation>
+            <xsd:documentation>Permet d'étendre &lt;OtherDimensions&gt; avec d'autres métadonnées de description des objets-données physiques.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    
+    <!-- In CoreMetadataType from seda-2.2-technical.xsd: extra Core TechnicalMetadata (Database, 3D, plan, ...) -->
+    <xsd:element name="OtherCoreTechnicalMetadataAbstract" abstract="true" type="OpenType">
+        <xsd:annotation>
+            <xsd:documentation>Contient toutes les métadonnées techniques de base pour d'autres types.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    
+    <!-- In ArchiveUnitType from seda-2.2-descriptive.xsd: Abstract for ArchiveUnit reference from within EAS -->
+    <xsd:element name="ArchiveUnitReferenceAbstract" abstract="true">
+        <xsd:annotation>
+            <xsd:documentation>Contient les requêtes nécessaires pour trouver un ArchiveUnit et pointer sur lui dans un prochain ArchiveUnit.
+                Permet de référencer un noeud déjà existant dans un arbre à partir d'un transfert précédent.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    
+    <!-- In ManagementGroup from seda-2.2-management.xsd: for Management extension -->
+    <xsd:element name="OtherManagementAbstract" abstract="true">
+        <xsd:annotation>
+            <xsd:documentation>Utilisé par exemple pour manipuler un ArchiveUnit déjà existant dans le système d'archivage électronique.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    
+    <!-- In CodeListVersionsType from seda-2.2-main.xsd: If needed, extra CodeList could be added -->
+    <xsd:element name="OtherCodeListAbstract" abstract="true" type="CodeType">
+        <xsd:annotation>
+            <xsd:documentation>Permet d'ajouter de nouvelles listes de codes si l'ajout d'autres métadonnées l'impose.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    
+    <!-- In EventGroup from seda-2.2-ontology.xsd: If needed, extra event could be added -->
+    <xsd:element name="EventAbstract" abstract="true">
+        <xsd:annotation>
+            <xsd:documentation>Permet d'ajouter de nouveau types d'événements dans l'ontologie.</xsd:documentation>
+        </xsd:annotation>
+    </xsd:element>
+    
+</xsd:schema>
+ 

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/BinaryDataObjectTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/BinaryDataObjectTest.java
@@ -41,6 +41,7 @@ class BinaryDataObjectTest {
 
         // Then
         String testOut = "{\n" +
+                "  \"dataObjectProfile\":null,\n" +
                 "  \"dataObjectSystemId\" : null,\n" +
                 "  \"dataObjectGroupSystemId\" : null,\n" +
                 "  \"relationshipsXmlData\" : [ ],\n" +

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackageTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/DataObjectPackageTest.java
@@ -118,6 +118,7 @@ class DataObjectPackageTest {
 
         String testog = "{\n" +
                 "  \"binaryDataObjectList\" : [ {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -179,6 +180,7 @@ class DataObjectPackageTest {
                 "    \"inDataObjectPackageId\" : \"ID17\",\n" +
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestSipDogMerge.zip-tmpdir\\\\content\\\\ID17.ods\"\n" +
                 "  }, {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -240,6 +242,7 @@ class DataObjectPackageTest {
                 "    \"inDataObjectPackageId\" : \"ID19\",\n" +
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestSipDogMerge.zip-tmpdir\\\\content\\\\ID19.txt\"\n" +
                 "  }, {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -301,6 +304,7 @@ class DataObjectPackageTest {
                 "    \"inDataObjectPackageId\" : \"ID23\",\n" +
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestSipDogMerge.zip-tmpdir\\\\content\\\\ID23.pdf\"\n" +
                 "  }, {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -362,6 +366,7 @@ class DataObjectPackageTest {
                 "    \"inDataObjectPackageId\" : \"ID24\",\n" +
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestSipDogMerge.zip-tmpdir\\\\content\\\\ID24.txt\"\n" +
                 "  }, {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -423,6 +428,7 @@ class DataObjectPackageTest {
                 "    \"inDataObjectPackageId\" : \"ID200\",\n" +
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestSipDogMerge.zip-tmpdir\\\\content\\\\ID200.json\"\n" +
                 "  }, {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -485,6 +491,7 @@ class DataObjectPackageTest {
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestSipDogMerge.zip-tmpdir\\\\content\\\\ID201.json\"\n" +
                 "  } ],\n" +
                 "  \"physicalDataObjectList\" : [ {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/PhysicalDataObjectTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/PhysicalDataObjectTest.java
@@ -41,6 +41,7 @@ class PhysicalDataObjectTest {
 
         // Then
         String testOut = "{\n" +
+                "  \"dataObjectProfile\":null,\n" +
                 "  \"dataObjectSystemId\" : null,\n" +
                 "  \"dataObjectGroupSystemId\" : null,\n" +
                 "  \"relationshipsXmlData\" : [ ],\n" +

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/SEDA2VersionTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/SEDA2VersionTest.java
@@ -9,21 +9,17 @@ import org.junit.jupiter.api.Test;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 
-public class Seda2VersionTest {
+public class SEDA2VersionTest {
     @Test
         // Test the SEDA2.1 and 2.2 construct from xml string (fromSedaXML)
     void testSeda2VersionComplianceTest() throws SEDALibException {
         // Given
-        Seda2Version.setSeda2Version(1);
+        SEDA2Version.setSeda2Version(1);
         Content c = new Content();
 
         String xmlFragments="  <Event>\n" +
@@ -53,7 +49,7 @@ public class Seda2VersionTest {
 
         // But in Seda2.2 version the LinkingAgentIdentifier is a recognized XML element and re-ordered before the
         // expansion field
-        Seda2Version.setSeda2Version(2);
+        SEDA2Version.setSeda2Version(2);
         c = new Content();
         c.addSedaXmlFragments(xmlFragments);
         cOut = c.toString();
@@ -64,7 +60,7 @@ public class Seda2VersionTest {
         // Test the SEDA2.1 to and from 2.2 conversion
     void testSeda2VersionConversionTest() throws SEDALibException {
         // Given
-        Seda2Version.setSeda2Version(1);
+        SEDA2Version.setSeda2Version(1);
         String xmlFragments="    <DataObjectPackage>\n" +
                 "    <DescriptiveMetadata>\n" +
                 "      <ArchiveUnit id=\"ID10\">\n" +
@@ -123,10 +119,10 @@ public class Seda2VersionTest {
         // Then the Event in ArchiveUnit has a LinkingAgentIdentifierType metadata
 
         try {
-            dop=Seda2Version.convertToSeda2Version(dop,2,null);
+            dop= SEDA2Version.convertToSeda2Version(dop,2,null);
         } catch (InterruptedException ignored) {
         }
-        Seda2Version.setSeda2Version(2);
+        SEDA2Version.setSeda2Version(2);
 
         c=dop.getArchiveUnitById("ID10").getContent();
         foundLinking=false;

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/Seda2VersionTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/core/Seda2VersionTest.java
@@ -1,0 +1,144 @@
+package fr.gouv.vitam.tools.sedalib.core;
+
+import fr.gouv.vitam.tools.sedalib.metadata.SEDAMetadata;
+import fr.gouv.vitam.tools.sedalib.metadata.content.*;
+import fr.gouv.vitam.tools.sedalib.metadata.namedtype.*;
+import fr.gouv.vitam.tools.sedalib.utils.SEDALibException;
+import fr.gouv.vitam.tools.sedalib.xml.SEDAXMLEventReader;
+import org.junit.jupiter.api.Test;
+
+import javax.xml.stream.XMLStreamException;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+public class Seda2VersionTest {
+    @Test
+        // Test the SEDA2.1 and 2.2 construct from xml string (fromSedaXML)
+    void testSeda2VersionComplianceTest() throws SEDALibException {
+        // Given
+        Seda2Version.setSeda2Version(1);
+        Content c = new Content();
+
+        String xmlFragments="  <Event>\n" +
+                "    <EventIdentifier>AUT-234452</EventIdentifier>\n" +
+                "    <EventTypeCode>Autorisation</EventTypeCode>\n" +
+                "    <EventDateTime>2104-05-31T01:00:00</EventDateTime>\n" +
+                "    <Outcome>OK</Outcome>\n" +
+                "    <AnyThing>OK</AnyThing>\n" +
+                "    <LinkingAgentIdentifier>\n" +
+                "      <LinkingAgentIdentifierType>Matricule</LinkingAgentIdentifierType>\n" +
+                "      <LinkingAgentIdentifierValue>123456789</LinkingAgentIdentifierValue>\n" +
+                "      <LinkingAgentRole>Archiviste</LinkingAgentRole>\n" +
+                "    </LinkingAgentIdentifier>\n" +
+                "  </Event>\n";
+        c.addSedaXmlFragments(xmlFragments);
+
+        // Test XML export depending on Seda2 version
+
+        String cOut = c.toString();
+
+        // Then in Seda2.1 version the LinkingAgentIdentifier is in expansion field and order is kept the same
+
+        String testOut = "<Content>\n" +
+                xmlFragments +
+                "</Content>";
+        assertThat(cOut).isEqualTo(testOut);
+
+        // But in Seda2.2 version the LinkingAgentIdentifier is a recognized XML element and re-ordered before the
+        // expansion field
+        Seda2Version.setSeda2Version(2);
+        c = new Content();
+        c.addSedaXmlFragments(xmlFragments);
+        cOut = c.toString();
+        assertThat(cOut).isNotEqualTo(testOut);
+    }
+
+    @Test
+        // Test the SEDA2.1 to and from 2.2 conversion
+    void testSeda2VersionConversionTest() throws SEDALibException {
+        // Given
+        Seda2Version.setSeda2Version(1);
+        String xmlFragments="    <DataObjectPackage>\n" +
+                "    <DescriptiveMetadata>\n" +
+                "      <ArchiveUnit id=\"ID10\">\n" +
+                "        <Content>\n" +
+                "          <DescriptionLevel>RecordGrp</DescriptionLevel>\n" +
+                "          <Title>Nouvelle ArchiveUnit</Title>\n" +
+                "          <Description>Ce test est pour voir ce qui se passe\n" +
+                "                  après 20 espaces</Description>\n" +
+                "          <Event>\n" +
+                "            <EventType>TyE</EventType>\n" +
+                "            <EventDateTime>2022-05-10T00:00:00</EventDateTime>\n" +
+                "            <EventDetail>DetE</EventDetail>\n" +
+                "            <LinkingAgentIdentifier>\n" +
+                "              <LinkingAgentIdentifierType>ty</LinkingAgentIdentifierType>\n" +
+                "              <LinkingAgentIdentifierValue>va</LinkingAgentIdentifierValue>\n" +
+                "              <LinkingAgentRole>ro</LinkingAgentRole>\n" +
+                "            </LinkingAgentIdentifier>\n" +
+                "            <Other>123</Other>\n" +
+                "          </Event>\n" +
+                "        </Content>\n" +
+                "      </ArchiveUnit>\n" +
+                "    </DescriptiveMetadata>\n" +
+                "    <ManagementMetadata>\n" +
+                "      <AcquisitionInformation>Acquisition Information</AcquisitionInformation>\n" +
+                "      <LegalStatus>Public Archive</LegalStatus>\n" +
+                "      <OriginatingAgencyIdentifier>Service_producteur</OriginatingAgencyIdentifier>\n" +
+                "      <SubmissionAgencyIdentifier>Service_versant</SubmissionAgencyIdentifier>\n" +
+                "    </ManagementMetadata>\n" +
+                "  </DataObjectPackage>";
+
+        // Test the import in Seda2.1
+
+        DataObjectPackage dop=null;
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(xmlFragments.getBytes(StandardCharsets.UTF_8));
+             SEDAXMLEventReader xmlReader = new SEDAXMLEventReader(bais)) {
+            xmlReader.nextUsefullEvent();
+            dop=DataObjectPackage.fromSedaXml(xmlReader, "", null);
+        } catch (XMLStreamException | IOException | InterruptedException e) {
+            assertThat(e).isNull();
+        }
+
+        Content c=dop.getArchiveUnitById("ID10").getContent();
+        boolean foundLinking=false;
+        for (SEDAMetadata sm : c.metadataList) {
+            if (sm.getXmlElementName().equals("Event")){
+                Event event=(Event) sm;
+                for (SEDAMetadata osm : event.metadataList){
+                    if (osm instanceof LinkingAgentIdentifierType)
+                        foundLinking=true;
+                }
+            }
+        }
+        assertThat(foundLinking).isFalse();
+
+
+        // Then the Event in ArchiveUnit has a LinkingAgentIdentifierType metadata
+
+        try {
+            dop=Seda2Version.convertToSeda2Version(dop,2,null);
+        } catch (InterruptedException ignored) {
+        }
+        Seda2Version.setSeda2Version(2);
+
+        c=dop.getArchiveUnitById("ID10").getContent();
+        foundLinking=false;
+        for (SEDAMetadata sm : c.metadataList) {
+            if (sm.getXmlElementName().equals("Event")){
+                Event event=(Event) sm;
+                for (SEDAMetadata osm : event.metadataList){
+                    if (osm instanceof LinkingAgentIdentifierType)
+                        foundLinking=true;
+                }
+            }
+        }
+        assertThat(foundLinking).isTrue();
+    }
+}

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/ArchiveDeliveryRequestReplyFromXmlTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/ArchiveDeliveryRequestReplyFromXmlTest.java
@@ -33,6 +33,7 @@ class ArchiveDeliveryRequestReplyFromXmlTest {
 		
 		String testog = "{\n" +
 				"  \"binaryDataObjectList\" : [ {\n" +
+				"    \"dataObjectProfile\":null,\n" +
 				"    \"dataObjectSystemId\" : null,\n" +
 				"    \"dataObjectGroupSystemId\" : null,\n" +
 				"    \"relationshipsXmlData\" : [ ],\n" +

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/CompressedFileImportTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/CompressedFileImportTest.java
@@ -65,6 +65,7 @@ class CompressedFileImportTest implements UseTestFiles {
         // assert one dataObjectGroup using serialization
         String testog = "{\n" +
                 "  \"binaryDataObjectList\" : [ {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -122,6 +123,7 @@ class CompressedFileImportTest implements UseTestFiles {
                 "    \"inDataObjectPackageId\" : \"ID17\",\n" +
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestImport.zip-tmpdir\\\\Root\\\\Node 1\\\\Node 1.1\\\\__BinaryMaster_1__201609-TdB-suivi-des-a.ods\"\n" +
                 "  }, {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -180,6 +182,7 @@ class CompressedFileImportTest implements UseTestFiles {
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\target\\\\tmpJunit\\\\TestImport.zip-tmpdir\\\\Root\\\\Node 1\\\\Node 1.1\\\\__TextContent_1__201609-TdB-suivi-des-a.txt\"\n" +
                 "  } ],\n" +
                 "  \"physicalDataObjectList\" : [ {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/DiskImportExportTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/DiskImportExportTest.java
@@ -63,6 +63,7 @@ class DiskImportExportTest implements UseTestFiles {
         // assert one dataObjectGroup using serialization
         String testog = "{\n" +
                 "  \"binaryDataObjectList\" : [ {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -120,6 +121,7 @@ class DiskImportExportTest implements UseTestFiles {
                 "    \"inDataObjectPackageId\" : \"ID14\",\n" +
                 "    \"onDiskPath\" : \"F:\\\\DocumentsPerso\\\\JS\\\\IdeaProjects\\\\sedatools\\\\sedalib\\\\src\\\\test\\\\resources\\\\PacketSamples\\\\SampleWithoutLinksModelV1\\\\Root\\\\Node 1\\\\Node 1.1\\\\__BinaryMaster_1_201609-TdB-suivi-des-a.ods\"\n" +
                 "  }, {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +
@@ -255,6 +257,7 @@ class DiskImportExportTest implements UseTestFiles {
         // assert one dataObjectGroup using serialization
         String testog = "{\n" +
                 "  \"binaryDataObjectList\" : [ {\n" +
+                "    \"dataObjectProfile\":null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
                 "    \"relationshipsXmlData\" : [ ],\n" +

--- a/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/SIPImportTest.java
+++ b/sedalib/src/test/java/fr/gouv/vitam/tools/sedalib/inout/SIPImportTest.java
@@ -57,6 +57,7 @@ class SIPImportTest implements UseTestFiles {
                 "    \"dataObjectGroupId\" : null,\n" +
                 "    \"dataObjectGroupReferenceId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
+                "    \"dataObjectProfile\" : null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectVersion\" : {\n" +
                 "      \"type\" : \"StringType\",\n" +
@@ -141,6 +142,7 @@ class SIPImportTest implements UseTestFiles {
                 "    \"dataObjectGroupId\" : null,\n" +
                 "    \"dataObjectGroupReferenceId\" : null,\n" +
                 "    \"dataObjectGroupSystemId\" : null,\n" +
+                "    \"dataObjectProfile\" : null,\n" +
                 "    \"dataObjectSystemId\" : null,\n" +
                 "    \"dataObjectVersion\" : {\n" +
                 "      \"type\" : \"StringType\",\n" +


### PR DESCRIPTION
- sedalib: add the global mechanism for managing other SEDA2 schema versions with different ontologies experimented on Event and LinkingAgentIdentifier (ComplexListType metadata with SEDA2 version depending definition)
- resip: add the SEDA2 version preference in the "Traitement/Interface" tab

Todo: use the global mechanism extend to all the SEDA2.2 differences in ontology
