### PR TITLE
Fix bump pom from 2.8.0 snapshot to 2.9.0 snapshot on master

### DIFF
--- a/mailextract/pom.xml
+++ b/mailextract/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/mailextract/pom.xml
+++ b/mailextract/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0</version>
+        <version>2.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/mailextractlib/pom.xml
+++ b/mailextractlib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/mailextractlib/pom.xml
+++ b/mailextractlib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0</version>
+        <version>2.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>fr.gouv.vitam.tools</groupId>
 		<artifactId>sedatools</artifactId>
-		<version>2.8.0-SNAPSHOT</version>
+		<version>2.8.0</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>sedatools-package</artifactId>

--- a/packaging/pom.xml
+++ b/packaging/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>fr.gouv.vitam.tools</groupId>
 		<artifactId>sedatools</artifactId>
-		<version>2.8.0</version>
+		<version>2.9.0-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	<artifactId>sedatools-package</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.gouv.vitam.tools</groupId>
     <artifactId>sedatools</artifactId>
-    <version>2.8.0</version>
+    <version>2.9.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>sedatools</name>
     <description>${project.artifactId}</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fr.gouv.vitam.tools</groupId>
     <artifactId>sedatools</artifactId>
-    <version>2.8.0-SNAPSHOT</version>
+    <version>2.8.0</version>
     <packaging>pom</packaging>
     <name>sedatools</name>
     <description>${project.artifactId}</description>

--- a/resip/pom.xml
+++ b/resip/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fr.gouv.vitam.tools</groupId>
         <artifactId>sedatools</artifactId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.0</version>
     </parent>
     <artifactId>resip</artifactId>
     <packaging>jar</packaging>

--- a/resip/pom.xml
+++ b/resip/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>fr.gouv.vitam.tools</groupId>
         <artifactId>sedatools</artifactId>
-        <version>2.8.0</version>
+        <version>2.9.0-SNAPSHOT</version>
     </parent>
     <artifactId>resip</artifactId>
     <packaging>jar</packaging>

--- a/sedalib-samples/pom.xml
+++ b/sedalib-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sedalib-samples/pom.xml
+++ b/sedalib-samples/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0</version>
+        <version>2.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/sedalib/pom.xml
+++ b/sedalib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/sedalib/pom.xml
+++ b/sedalib/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0</version>
+        <version>2.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/testsipgenerator/pom.xml
+++ b/testsipgenerator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0-SNAPSHOT</version>
+        <version>2.8.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>

--- a/testsipgenerator/pom.xml
+++ b/testsipgenerator/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>sedatools</artifactId>
         <groupId>fr.gouv.vitam.tools</groupId>
-        <version>2.8.0</version>
+        <version>2.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>jar</packaging>


### PR DESCRIPTION
Story #13188: Releasing 2.8.0 with new resip-standalone (including JRE).